### PR TITLE
add scheduler manifest

### DIFF
--- a/cmd/cluster-kube-controller-manager-operator/main.go
+++ b/cmd/cluster-kube-controller-manager-operator/main.go
@@ -13,6 +13,7 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 
+	"github.com/openshift/cluster-kube-controller-manager-operator/cmd/cluster-kube-controller-manager-operator/render"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/operator"
 )
 
@@ -43,6 +44,7 @@ func NewSSCSCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(operator.NewOperator())
+	cmd.AddCommand(render.NewRenderCommand())
 
 	return cmd
 }

--- a/cmd/cluster-kube-controller-manager-operator/render/config.go
+++ b/cmd/cluster-kube-controller-manager-operator/render/config.go
@@ -1,0 +1,30 @@
+package render
+
+type Config struct {
+	// ConfigHostPath is a host path mounted into the controller manager pods to hold the config file.
+	ConfigHostPath string
+
+	// ConfigFileName is the filename of config file inside ConfigHostPath.
+	ConfigFileName string
+
+	// CloudProviderHostPath is a host path mounted into the apiserver pods to hold cloud provider configuration.
+	CloudProviderHostPath string
+
+	// SecretsHostPath holds certs and keys
+	SecretsHostPath string
+
+	// Namespace is the target namespace for the bootstrap controller manager to be created.
+	Namespace string
+
+	// Image is the pull spec of the image to use for the controller manager.
+	Image string
+
+	// ImagePullPolicy specifies the image pull policy to use for the images.
+	ImagePullPolicy string
+
+	// PostBootstrapKubeControllerManagerConfig holds the rendered kube-controller-manager config file after bootstrapping.
+	PostBootstrapKubeControllerManagerConfig []byte
+
+	// Assets holds the loaded assets like certs and keys.
+	Assets map[string][]byte
+}

--- a/cmd/cluster-kube-controller-manager-operator/render/render.go
+++ b/cmd/cluster-kube-controller-manager-operator/render/render.go
@@ -1,0 +1,200 @@
+package render
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/v311_00_assets"
+	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+const (
+	bootstrapVersion = "v3.11.0"
+)
+
+// manifestOpts holds values to parametrize the manifests
+type manifestOpts struct {
+	namespace             string
+	image                 string
+	imagePullPolicy       string
+	configHostPath        string
+	configFileName        string
+	cloudProviderHostPath string
+	secretsHostPath       string
+}
+
+// renderOpts holds values to drive the render command.
+type renderOpts struct {
+	manifest manifestOpts
+
+	templatesDir       string
+	assetInputDir      string
+	assetOutputDir     string
+	configOverrideFile string
+	configOutputFile   string
+}
+
+func NewRenderCommand() *cobra.Command {
+	renderOpts := &renderOpts{}
+	cmd := &cobra.Command{
+		Use:   "render",
+		Short: "Render kubernetes controller manager bootstrap manifests, secrets and configMaps",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := renderOpts.Validate(); err != nil {
+				glog.Fatal(err)
+			}
+			if err := renderOpts.Run(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&renderOpts.manifest.namespace, "manifest-namespace", "openshift-kube-controller-manager",
+		"Target namespace for controller manager pods.")
+	cmd.Flags().StringVar(&renderOpts.manifest.image, "manifest-image", "openshift/origin-hypershift:latest",
+		"Image to use for the controller manager.")
+	cmd.Flags().StringVar(&renderOpts.manifest.imagePullPolicy, "manifest-image-pull-policy", "IfNotPresent",
+		"Image pull policy to use for the controller manager.")
+	cmd.Flags().StringVar(&renderOpts.manifest.configHostPath, "manifest-config-host-path", "/etc/kubernetes/bootstrap-configs",
+		"A host path mounted into the controller manager pods to hold a config file.")
+	cmd.Flags().StringVar(&renderOpts.manifest.secretsHostPath, "manifest-secrets-host-path", "/etc/kubernetes/bootstrap-secrets",
+		"A host path mounted into the controller manager pods to hold secrets.")
+	cmd.Flags().StringVar(&renderOpts.manifest.configFileName, "manifest-config-file-name", "kube-controller-manager-config.yaml",
+		"The config file name inside the manifest-config-host-path.")
+	cmd.Flags().StringVar(&renderOpts.manifest.cloudProviderHostPath, "manifest-cloud-provider-host-path", "/etc/kubernetes/cloud",
+		"A host path mounted into the controller manager pods to hold cloud provider configuration.")
+
+	cmd.Flags().StringVar(&renderOpts.assetOutputDir, "asset-output-dir", "", "Output path for rendered manifests.")
+	cmd.Flags().StringVar(&renderOpts.assetInputDir, "asset-input-dir", "", "A path to directory with certificates and secrets.")
+	cmd.Flags().StringVar(&renderOpts.templatesDir, "templates-input-dir", "/usr/share/bootkube/manifests", "A path to a directory with manifest templates.")
+	cmd.Flags().StringVar(&renderOpts.configOverrideFile, "config-override-file", "", "A sparse KubeControllerManagerConfig.kubecontrolplane."+
+		"config.openshift.io/v1 file (default: kube-controller-manager-config-overrides.yaml in the asset-input-dir)")
+	cmd.Flags().StringVar(&renderOpts.configOutputFile, "config-output-file", "", "Output path for the KubeControllerManagerConfig yaml file.")
+
+	return cmd
+}
+
+func (r *renderOpts) Validate() error {
+	if len(r.manifest.namespace) == 0 {
+		return errors.New("missing required flag: --manifest-namespace")
+	}
+	if len(r.manifest.image) == 0 {
+		return errors.New("missing required flag: --manifest-image")
+	}
+	if len(r.manifest.imagePullPolicy) == 0 {
+		return errors.New("missing required flag: --manifest-image-pull-policy")
+	}
+	if len(r.manifest.configHostPath) == 0 {
+		return errors.New("missing required flag: --manifest-config-host-path")
+	}
+	if len(r.manifest.configFileName) == 0 {
+		return errors.New("missing required flag: --manifest-config-file-name")
+	}
+	if len(r.manifest.cloudProviderHostPath) == 0 {
+		return errors.New("missing required flag: --manifest-cloud-provider-host-path")
+	}
+	if len(r.manifest.secretsHostPath) == 0 {
+		return errors.New("missing required flag: --manifest-secrets-host-path")
+	}
+
+	if len(r.assetInputDir) == 0 {
+		return errors.New("missing required flag: --asset-output-dir")
+	}
+	if len(r.assetOutputDir) == 0 {
+		return errors.New("missing required flag: --asset-input-dir")
+	}
+	if len(r.templatesDir) == 0 {
+		return errors.New("missing required flag: --templates-dir")
+	}
+	if len(r.configOutputFile) == 0 {
+		return errors.New("missing required flag: --config-output-file")
+	}
+
+	return nil
+}
+
+func (r *renderOpts) complete() error {
+	if len(r.configOverrideFile) == 0 {
+		r.configOverrideFile = filepath.Join(r.assetInputDir, "kube-controller-manager-config-overrides.yaml")
+	}
+
+	return nil
+}
+
+func (r *renderOpts) Run() error {
+	if err := r.complete(); err != nil {
+		return err
+	}
+
+	renderConfig := Config{
+		Namespace:             r.manifest.namespace,
+		Image:                 r.manifest.image,
+		ImagePullPolicy:       r.manifest.imagePullPolicy,
+		ConfigHostPath:        r.manifest.configHostPath,
+		ConfigFileName:        r.manifest.configFileName,
+		CloudProviderHostPath: r.manifest.cloudProviderHostPath,
+		SecretsHostPath:       r.manifest.secretsHostPath,
+	}
+
+	// create post-poststrap configuration
+	var err error
+	renderConfig.PostBootstrapKubeControllerManagerConfig, err = r.configFromDefaultsPlusOverride(filepath.Join(r.templatesDir, "config", "config-overrides.yaml"))
+
+	// load and render templates
+	if renderConfig.Assets, err = assets.LoadFilesRecursively(r.assetInputDir); err != nil {
+		return fmt.Errorf("failed loading assets from %q: %v", r.assetInputDir, err)
+	}
+	for _, manifestDir := range []string{"bootstrap-manifests", "manifests"} {
+		manifests, err := assets.New(filepath.Join(r.templatesDir, manifestDir), renderConfig, assets.OnlyYaml)
+		if err != nil {
+			return fmt.Errorf("failed rendering assets: %v", err)
+		}
+		if err := manifests.WriteFiles(filepath.Join(r.assetOutputDir, manifestDir)); err != nil {
+			return fmt.Errorf("failed writing assets to %q: %v", filepath.Join(r.assetOutputDir, manifestDir), err)
+		}
+	}
+
+	// create bootstrap configuration
+	mergedConfig, err := r.configFromDefaultsPlusOverride(filepath.Join(r.templatesDir, "config", "bootstrap-config-overrides.yaml"))
+	if err != nil {
+		return fmt.Errorf("failed to generated bootstrap config: %v", err)
+	}
+	if err := ioutil.WriteFile(r.configOutputFile, mergedConfig, 0644); err != nil {
+		return fmt.Errorf("failed to write merged config to %q: %v", r.configOutputFile, err)
+	}
+
+	return nil
+}
+
+func (r *renderOpts) configFromDefaultsPlusOverride(tlsOverride string) ([]byte, error) {
+	defaultConfig := v311_00_assets.MustAsset(filepath.Join(bootstrapVersion, "kube-controller-manager", "defaultconfig.yaml"))
+	bootstrapOverrides, err := ioutil.ReadFile(tlsOverride)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config override file %q: %v", tlsOverride, err)
+	}
+	configs := [][]byte{defaultConfig, bootstrapOverrides}
+	if len(r.configOverrideFile) > 0 {
+		overrides, err := ioutil.ReadFile(r.configOverrideFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load config overrides at %q: %v", r.configOverrideFile, err)
+		}
+		configs = append(configs, overrides)
+	}
+	mergedConfig, err := resourcemerge.MergeProcessConfig(nil, configs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge configs: %v", err)
+	}
+	yml, err := yaml.JSONToYAML(mergedConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return yml, nil
+}

--- a/manifests/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/manifests/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -1,0 +1,51 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: bootstrap-kube-controller-manager
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: "controller-manager"
+  annotations:
+    openshift.io/run-level: "0"
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: kube-controller-manager
+    image: {{ .Image }}
+    imagePullPolicy: {{ .ImagePullPolicy }}
+    command: ["/bin/bash", "-c"]
+    args:
+    - exec hyperkube kube-controller-manager --config=/etc/kubernetes/config/{{ .ConfigFileName }}
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+    - mountPath: /etc/kubernetes/secrets
+      name: secrets
+      readOnly: true
+    - mountPath: /etc/kubernetes/cloud
+      name: etc-kubernetes-cloud
+      readOnly: true
+    - mountPath: /etc/kubernetes/config
+      name: config
+      readOnly: true
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 8444
+        path: healthz
+  volumes:
+  - hostPath:
+      path: {{ .SecretsHostPath }}
+    name: secrets
+  - hostPath:
+      path: {{ .CloudProviderHostPath }}
+    name: etc-kubernetes-cloud
+  - hostPath:
+      path: {{ .ConfigHostPath }}
+    name: config
+  - hostPath:
+      path: /etc/ssl/certs
+    name: ssl-certs-host

--- a/manifests/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/manifests/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -1,0 +1,28 @@
+# NOTE: This belongs to scheduler operator, but we need this pass the initial bootstrap now.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-kube-scheduler
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: "scheduler"
+  annotations:
+    openshift.io/run-level: "0"
+spec:
+  containers:
+  - name: kube-scheduler
+    image: {{ .Image }}
+    imagePullPolicy: {{ .ImagePullPolicy }}
+    command: ["/bin/bash", "-c"]
+    args:
+    - exec hyperkube scheduler --kubeconfig=/etc/kubernetes/secrets/kubeconfig --config=/etc/kubernetes/config/scheduler.yaml
+    volumeMounts:
+    - mountPath: /etc/kubernetes/secrets
+      name: secrets
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: {{ .SecretsHostPath }}
+    name: secrets


### PR DESCRIPTION
This belongs to scheduler operator, but we can't wait for it now and we need to pass the bootstrapping. Logically this is closer to controller-manager than API server.

The scheduler have hardcoded config path, @sttts I guess we will need some config that will work :)

Also adds `--skip-scheduler` flag to render (in case we want to switch this off, like when scheduler operator will provide its bootstrap manifest)