### PR TITLE
make render produce minimal running config for later customization

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,10 +1,6 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
-serviceServingCert:
-  certFile: service-signer.crt
 extendedArguments:
-  cloud-config:
-  - "/etc/kubernetes/cloud/config"
   root-ca-file:
   - "/etc/kubernetes/secrets/root-ca.crt"
   service-account-private-key-file:

--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,10 +1,6 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
-serviceServingCert:
-  certFile: service-signer.crt
 extendedArguments:
-  cloud-config:
-  - "/etc/kubernetes/cloud/config"
   root-ca-file:
   - "/etc/kubernetes/secrets/root-ca.crt"
   service-account-private-key-file:

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -1,14 +1,10 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
-serviceServingCert:
-  certFile: service-signer.crt
 extendedArguments:
   enable-dynamic-provisioning:
   - "true"
   allocate-node-cidrs:
   - "true"
-  cloud-provider:
-  - "metal" # TODO: override this through the installer
   configure-cloud-routes:
   - "false"
   cluster-cidr:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -79,15 +79,11 @@ func v3110KubeApiserverCmYaml() (*asset, error) {
 
 var _v3110KubeApiserverDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
-serviceServingCert:
-  certFile: service-signer.crt
 extendedArguments:
   enable-dynamic-provisioning:
   - "true"
   allocate-node-cidrs:
   - "true"
-  cloud-provider:
-  - "metal" # TODO: override this through the installer
   configure-cloud-routes:
   - "false"
   cluster-cidr:


### PR DESCRIPTION
We need to simplify the rendered config to be compatible with non-old cluster-up clusters.

/assign @mfojtik 