### PR TITLE
add fake scheduler and checkpointer to pass bootkube start

### DIFF
--- a/bindata/bootkube/manifests/fake-checkpointer-daemonset.yaml
+++ b/bindata/bootkube/manifests/fake-checkpointer-daemonset.yaml
@@ -1,0 +1,38 @@
+# NOTE: This is just dummy pod that should be replaced by real checkpointer in real installer. For now, this allow us to move
+# forward with cluster up bootkube.
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: pod-checkpointer
+    tectonic-operators.coreos.com/managed-by: kube-core-operator
+    tier: control-plane
+  name: pod-checkpointer
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: pod-checkpointer
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        checkpointer.alpha.coreos.com/checkpoint: "true"
+      labels:
+        k8s-app: pod-checkpointer
+        tier: control-plane
+    spec:
+      containers:
+      - command: ["/bin/bash", "-c"]
+        args: ["sleep", "infinity"]
+        image: {{ .Image }}
+        imagePullPolicy: {{ .ImagePullPolicy }}
+        name: pod-checkpointer
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      restartPolicy: Always
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/bindata/bootkube/manifests/fake-kube-scheduler-deployment.yaml
+++ b/bindata/bootkube/manifests/fake-kube-scheduler-deployment.yaml
@@ -1,0 +1,48 @@
+# NOTE: This belongs to scheduler operator, but we need this pass the initial bootstrap now.
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: kube-scheduler
+    tectonic-operators.coreos.com/managed-by: kube-core-operator
+    tier: control-plane
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-scheduler
+      tier: control-plane
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: kube-scheduler
+        tier: control-plane
+    spec:
+      containers:
+      - name: kube-scheduler
+        image: {{ .Image }}
+        imagePullPolicy: {{ .ImagePullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+        - exec hyperkube scheduler --kubeconfig=/etc/kubernetes/secrets/kubeconfig --leader-elect=true
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secrets
+          name: secrets
+          readOnly: true
+        name: kube-scheduler
+      volumes:
+      - hostPath:
+        path: {{ .SecretsHostPath }}
+        name: secrets
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534


### PR DESCRIPTION
This is what we need to trick bootkube start and finish the phase 1, so bootkube will tear down the static pods and release the locks for daemonsets.

/cc @sttts 
/cc @deads2k 