### PR TITLE
fix: kinds for controllermanageroperatorconfig

### DIFF
--- a/manifests/00_clusterkubecontrollermanageroperator_01_config.crd.yaml
+++ b/manifests/00_clusterkubecontrollermanageroperator_01_config.crd.yaml
@@ -7,7 +7,7 @@ spec:
   group: kubecontrollermanager.operator.openshift.io
   version: v1alpha1
   names:
-    kind: KubeApiserverOperatorConfig
+    kind: KubeControllerManagerOperatorConfig
     plural: kubecontrollermanageroperatorconfigs
     singular: kubecontrollermanageroperatorconfig
   subresources:

--- a/manifests/00_clusterkubecontrollermanageroperator_02_config.yaml
+++ b/manifests/00_clusterkubecontrollermanageroperator_02_config.yaml
@@ -1,5 +1,5 @@
 apiVersion: kubecontrollermanager.operator.openshift.io/v1alpha1
-kind: KubeApiserverOperatorConfig
+kind: KubeControllerManagerOperatorConfig
 metadata:
   name: instance
 spec:


### PR DESCRIPTION
discovery restmapper fails to resolve this mismatch in name and kind.
```go
func gvkToGVR(gvk schema.GroupVersionKind, restMapper *restmapper.DeferredDiscoveryRESTMapper) (*schema.GroupVersionResource, bool, error) {
	mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
	if err != nil {
		return nil, false, fmt.Errorf("failed to get the resource REST mapping for GroupVersionKind(%s): %v", gvk.String(), err)
	}

	return &mapping.Resource, mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil
}
```