### PR TITLE
add locking to prevent host port conflicts

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -11,14 +11,36 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
-  containers:
-  - name: kube-controller-manager
+  securityContext:
+    supplementalGroups: [65534]
+    privileged: true
+  initContainers:
+  - name: setup-lock-dir
     image: {{ .Image }}
     imagePullPolicy: {{ .ImagePullPolicy }}
     command: ["/bin/bash", "-c"]
     args:
+    - |
+      chgrp 65534 /var/lock
+      chmod 775 /var/lock
+      rm -f /var/lock/controller-manager.lock || true
+    securityContext:
+      runAsNonRoot: false
+      privileged: true
+    volumeMounts:
+    - mountPath: /var/lock
+      name: var-lock
+  containers:
+  - name: kube-controller-manager
+    image: {{ .Image }}
+    imagePullPolicy: {{ .ImagePullPolicy }}
+    command: ["/usr/bin/flock", "--exclusive", "--timeout=60", "/var/lock/controller-manager.lock", "-c"]
+    args:
     - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     volumeMounts:
+    - mountPath: /var/lock
+      name: var-lock
+      readOnly: false
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
@@ -37,6 +59,9 @@ spec:
         port: 10252
         path: healthz
   volumes:
+  - hostPath:
+      path: {{ .LockHostPath }}
+    name: var-lock
   - hostPath:
       path: {{ .SecretsHostPath }}
     name: secrets

--- a/bindata/bootkube/manifests/fake-kube-scheduler-deployment.yaml
+++ b/bindata/bootkube/manifests/fake-kube-scheduler-deployment.yaml
@@ -37,6 +37,7 @@ spec:
           name: secrets
           readOnly: true
         name: kube-scheduler
+        hostNetwork: true
       volumes:
       - hostPath:
           path: {{ .SecretsHostPath }}

--- a/bindata/bootkube/manifests/kube-controller-manager-daemonset.yaml
+++ b/bindata/bootkube/manifests/kube-controller-manager-daemonset.yaml
@@ -29,13 +29,16 @@ spec:
       - name: kube-controller-manager
         image: {{ .Image }}
         imagePullPolicy: {{ .ImagePullPolicy }}
-        command: ["/bin/bash", "-c"]
+        command: ["/usr/bin/flock", "--exclusive", "--timeout=60", "/var/lock/controller-manager.lock", "-c"]
         args:
         - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig --master=https://kubernetes.default.svc
         securityContext:
           runAsNonRoot: true
           runAsUser: 65534
         volumeMounts:
+        - mountPath: /var/lock
+          name: var-lock
+          readOnly: false
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
           readOnly: true
@@ -48,6 +51,7 @@ spec:
         - mountPath: /etc/kubernetes/config
           name: config
           readOnly: true
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
@@ -55,6 +59,9 @@ spec:
         operator: Exists
         effect: NoSchedule
       volumes:
+      - hostPath:
+          path: {{ .LockHostPath }}
+        name: var-lock
       - hostPath:
           path: {{ .SecretsHostPath }}
         name: secrets

--- a/cmd/cluster-kube-controller-manager-operator/render/config.go
+++ b/cmd/cluster-kube-controller-manager-operator/render/config.go
@@ -16,6 +16,9 @@ type Config struct {
 	// Namespace is the target namespace for the bootstrap controller manager to be created.
 	Namespace string
 
+	// LockHostPath holds the api server lock file for bootstrap
+	LockHostPath string
+
 	// Image is the pull spec of the image to use for the controller manager.
 	Image string
 

--- a/cmd/cluster-kube-controller-manager-operator/render/render.go
+++ b/cmd/cluster-kube-controller-manager-operator/render/render.go
@@ -30,6 +30,7 @@ type manifestOpts struct {
 	configHostPath        string
 	configFileName        string
 	cloudProviderHostPath string
+	lockHostPath          string
 	secretsHostPath       string
 }
 
@@ -75,6 +76,8 @@ func NewRenderCommand() *cobra.Command {
 		"The config file name inside the manifest-config-host-path.")
 	cmd.Flags().StringVar(&renderOpts.manifest.cloudProviderHostPath, "manifest-cloud-provider-host-path", "/etc/kubernetes/cloud",
 		"A host path mounted into the controller manager pods to hold cloud provider configuration.")
+	cmd.Flags().StringVar(&renderOpts.manifest.lockHostPath, "manifest-lock-host-path", "/var/run/kubernetes/lock",
+		"A host path mounted into the controller manager pods to hold lock.")
 
 	cmd.Flags().StringVar(&renderOpts.assetOutputDir, "asset-output-dir", "", "Output path for rendered manifests.")
 	cmd.Flags().StringVar(&renderOpts.assetInputDir, "asset-input-dir", "", "A path to directory with certificates and secrets.")
@@ -111,7 +114,9 @@ func (r *renderOpts) Validate() error {
 	if len(r.manifest.secretsHostPath) == 0 {
 		return errors.New("missing required flag: --manifest-secrets-host-path")
 	}
-
+	if len(r.manifest.lockHostPath) == 0 {
+		return errors.New("missing required flag: --manifest-lock-host-path")
+	}
 	if len(r.assetInputDir) == 0 {
 		return errors.New("missing required flag: --asset-output-dir")
 	}
@@ -149,6 +154,7 @@ func (r *renderOpts) Run() error {
 		ConfigFileName:        r.manifest.configFileName,
 		CloudProviderHostPath: r.manifest.cloudProviderHostPath,
 		SecretsHostPath:       r.manifest.secretsHostPath,
+		LockHostPath:          r.manifest.lockHostPath,
 	}
 
 	// create post-poststrap configuration


### PR DESCRIPTION
This add locking mechanism similar to what API server using to prevent the host port conflicts. For cluster up the controller manager has to use the hostNetwork otherwise the connection to API server will fail and the pods created by daemonsets will keep hanging. With this I can get the controller manager operating.

/cc @deads2k 
/cc @sttts 
/cc @openshift/sig-master 