### PR TITLE
fix selinux errors in lock dirs

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -13,7 +13,6 @@ spec:
   hostNetwork: true
   securityContext:
     supplementalGroups: [65534]
-    privileged: true
   initContainers:
   - name: setup-lock-dir
     image: {{ .Image }}
@@ -32,6 +31,10 @@ spec:
       name: var-lock
   containers:
   - name: kube-controller-manager
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      privileged: true
     image: {{ .Image }}
     imagePullPolicy: {{ .ImagePullPolicy }}
     command: ["/usr/bin/flock", "--exclusive", "--timeout=60", "/var/lock/controller-manager.lock", "-c"]

--- a/bindata/bootkube/manifests/kube-controller-manager-daemonset.yaml
+++ b/bindata/bootkube/manifests/kube-controller-manager-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command: ["/usr/bin/flock", "--exclusive", "--timeout=60", "/var/lock/controller-manager.lock", "-c"]
         args:
-        - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig --master=https://kubernetes.default.svc
+        - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig
         securityContext:
           runAsNonRoot: true
           runAsUser: 65534


### PR DESCRIPTION
This also force controller manager daemonset to run on hostNetwork and use the localhost to reach out to API server. With this change I can see the controller manager successfully establishing connection to API server and running the controllers.

/cc @soltysh 

