### PR TITLE
manifests: fix invalid yaml

### DIFF
--- a/manifests/0000_12_cluster-kube-controller-manager-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_12_cluster-kube-controller-manager-operator_04_clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-  metadata:
-    name: system:openshift:operator:cluster-kube-controller-manager-operator
-  roleRef:
-    kind: ClusterRole
-    name: cluster-admin
-  subjects:
-  - kind: ServiceAccount
-    namespace: openshift-core-operators
-    name: openshift-cluster-kube-controller-manager-operator
+metadata:
+  name: system:openshift:operator:cluster-kube-controller-manager-operator
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-core-operators
+  name: openshift-cluster-kube-controller-manager-operator


### PR DESCRIPTION
This is causing issue in CVO when reading the manifest
```console
error parsing 0000_12_cluster-kube-controller-manager-operator_04_clusterrolebinding.yaml: error parsing:
    error converting YAML to JSON: yaml: line 3: mapping values are not allowed in this context
```