### PR TITLE
render: pluralize --config-overrides-file

### DIFF
--- a/cmd/cluster-kube-controller-manager-operator/render/render.go
+++ b/cmd/cluster-kube-controller-manager-operator/render/render.go
@@ -37,11 +37,11 @@ type manifestOpts struct {
 type renderOpts struct {
 	manifest manifestOpts
 
-	templatesDir       string
-	assetInputDir      string
-	assetOutputDir     string
-	configOverrideFile string
-	configOutputFile   string
+	templatesDir        string
+	assetInputDir       string
+	assetOutputDir      string
+	configOverrideFiles []string
+	configOutputFile    string
 
 	skipSchedulerBootstrapManifest bool
 }
@@ -79,8 +79,7 @@ func NewRenderCommand() *cobra.Command {
 	cmd.Flags().StringVar(&renderOpts.assetOutputDir, "asset-output-dir", "", "Output path for rendered manifests.")
 	cmd.Flags().StringVar(&renderOpts.assetInputDir, "asset-input-dir", "", "A path to directory with certificates and secrets.")
 	cmd.Flags().StringVar(&renderOpts.templatesDir, "templates-input-dir", "/usr/share/bootkube/manifests", "A path to a directory with manifest templates.")
-	cmd.Flags().StringVar(&renderOpts.configOverrideFile, "config-override-file", "", "A sparse KubeControllerManagerConfig.kubecontrolplane."+
-		"config.openshift.io/v1 file (default: kube-controller-manager-config-overrides.yaml in the asset-input-dir)")
+	cmd.Flags().StringSliceVar(&renderOpts.configOverrideFiles, "config-override-files", nil, "Additional sparse KubeControllerManagerConfig.kubecontrolplane.config.openshift.io/v1 files for customiziation through the installer, merged into the default config in the given order.")
 	cmd.Flags().StringVar(&renderOpts.configOutputFile, "config-output-file", "", "Output path for the KubeControllerManagerConfig yaml file.")
 
 	// TODO: Remove this when the render command exists in scheduler operator
@@ -129,10 +128,6 @@ func (r *renderOpts) Validate() error {
 }
 
 func (r *renderOpts) complete() error {
-	if len(r.configOverrideFile) == 0 {
-		r.configOverrideFile = filepath.Join(r.assetInputDir, "kube-controller-manager-config-overrides.yaml")
-	}
-
 	return nil
 }
 
@@ -195,10 +190,10 @@ func (r *renderOpts) configFromDefaultsPlusOverride(data *Config, tlsOverride st
 		return nil, fmt.Errorf("failed to load config override file %q: %v", tlsOverride, err)
 	}
 	configs := [][]byte{defaultConfig, bootstrapOverrides}
-	if len(r.configOverrideFile) > 0 {
-		overrides, err := readFileTemplate(r.configOverrideFile, data)
+	for _, fname := range r.configOverrideFiles {
+		overrides, err := readFileTemplate(fname, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load config overrides at %q: %v", r.configOverrideFile, err)
+			return nil, fmt.Errorf("failed to load config overrides at %q: %v", fname, err)
 		}
 
 		configs = append(configs, overrides)


### PR DESCRIPTION
This is version  of https://github.com/openshift/cluster-kube-apiserver-operator/pull/69 where we don't remove the flag that is currently being used by installer but just mark it deprecated and hide it.

We can remove the flag once we fix the installer, but for now it will break the bootstrap.sh script installer use and will prevent this PR from merging.

We can revert the last commit when the installer move forward.

/cc @sttts 