### PR TITLE
Fix kube-controller-manager-config name

### DIFF
--- a/bindata/bootkube/manifests/configmap-kube-controller-manager-config.yaml
+++ b/bindata/bootkube/manifests/configmap-kube-controller-manager-config.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-controller-manager-config
-  namespace: {{ .Namespace }}
-data:
-  config.yaml: |
-    {{ .PostBootstrapKubeControllerManagerConfig | indent 4 }}

--- a/bindata/v3.11.0/kube-controller-manager/cm.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/cm.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-controller-manager
-  name: deployment-controller-manager-config
+  name: deployment-kube-controller-manager-config
 data:
   config.yaml:

--- a/bindata/v3.11.0/kube-controller-manager/deployment.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: controller-manager-config
+          name: deployment-kube-controller-manager-config
       - name: cluster-signing-ca
         secret:
           secretName: cluster-signing-ca

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -58,7 +58,7 @@ var _v3110KubeControllerManagerCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-controller-manager
-  name: deployment-controller-manager-config
+  name: deployment-kube-controller-manager-config
 data:
   config.yaml:
 `)
@@ -178,7 +178,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: controller-manager-config
+          name: deployment-kube-controller-manager-config
       - name: cluster-signing-ca
         secret:
           secretName: cluster-signing-ca


### PR DESCRIPTION
There was a name mismatch before this PR.

Also we don't use the config created by the render command in the openshift-kube-controller-manager namespace.