### PR TITLE
Makefile: remove origin-release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,18 +33,3 @@ images:
 clean:
 	$(RM) ./cluster-kube-controller-manager-operator
 .PHONY: clean
-
-, := ,
-IMAGES ?= cluster-kube-controller-manager-operator
-QUOTED_IMAGES=\"$(subst $(,),\"$(,)\",$(IMAGES))\"
-
-origin-release:
-	docker pull registry.svc.ci.openshift.org/openshift/origin-release:v4.0
-	imagebuilder -file hack/lib/Dockerfile-origin-release --build-arg "IMAGE_REPOSITORY_NAME=$(IMAGE_REPOSITORY_NAME)" --build-arg "IMAGES=$(QUOTED_IMAGES)" -t "$(IMAGE_REPOSITORY_NAME)/origin-release:latest" hack
-	@echo
-	@echo "To install:"
-	@echo
-	@echo "  IMAGE_REPOSITORY_NAME=$(IMAGE_REPOSITORY_NAME) make images"
-	@echo "  docker push $(IMAGE_REPOSITORY_NAME)/origin-release:latest"
-	@echo "  docker push $(IMAGE_REPOSITORY_NAME)/origin-cluster-kube-controller-manager-operator"
-	@echo "  OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(IMAGE_REPOSITORY_NAME)/origin-release:latest bin/openshift-install cluster --log-level=debug"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # cluster-kube-controller-manager-operator
+
 The kube-controller-manager operator installs and maintains the kube-controller-manager on a cluster
+
+## Developing and debugging the bootkube bootstrap phase
+
+The operator image version used by the [https://github.com/openshift/installer/blob/master/pkg/asset/ignition/bootstrap/content/bootkube.go#L86](installer) bootstrap phase can be overridden by creating a custom origin-release image pointing to the developer's operator `:latest` image:
+
+```
+$ IMAGE_REPOSITORY_NAME=sttts make images
+$ docker push sttts/origin-cluster-kube-controller-manager-operator
+
+$ cd ../cluster-kube-apiserver-operator
+$ IMAGES=cluster-kube-controller-manager-operator IMAGE_REPOSITORY_NAME=sttts make origin-release
+$ docker push sttts/origin-release:latest
+
+$ cd ../installer
+$ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=docker.io/sttts/origin-release:latest bin/openshift-install cluster ...
+```

--- a/hack/lib/Dockerfile-origin-release
+++ b/hack/lib/Dockerfile-origin-release
@@ -1,9 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/origin-release:v4.0 as origin-release
-
-FROM fedora:29 as jq
-RUN yum install -y jq
-COPY --from=origin-release release-manifests/image-references .
-RUN jq '.spec.tags |= map(.name as $name | if ([IMAGES] | index($name)) then .from.name |= "docker.io/DOCKER_ORG/origin-"+$name+":latest" else . end)' image-references > image-references-updated
-
-FROM registry.svc.ci.openshift.org/openshift/origin-release:v4.0
-COPY --from=jq image-references-updated release-manifests/image-references


### PR DESCRIPTION
Instead use the very same cluster-kube-apiserver-operator target:

```
$ IMAGE_REPOSITORY_NAME=sttts make images
$ docker push sttts/origin-cluster-kube-controller-manager-operator
$ cd ../cluster-kube-apiserver-operator
$ IMAGES=cluster-kube-controller-manager-operator IMAGE_REPOSITORY_NAME=sttts make origin-release
$ docker push sttts/origin-release:latest
```