### PR TITLE
add liveness and readiness probes to static pod

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -15,6 +15,8 @@ spec:
   - name: kube-controller-manager
     image: {{ .Image }}
     imagePullPolicy: {{ .ImagePullPolicy }}
+    ports:
+      - containerPort: 10257
     command: ["/bin/bash", "-c"]
     args:
     - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig
@@ -33,9 +35,11 @@ spec:
       readOnly: true
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
+      initialDelaySeconds: 45
+      timeoutSeconds: 10
   volumes:
   - hostPath:
       path: {{ .SecretsHostPath }}

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -9,6 +9,8 @@ extendedArguments:
   - "/etc/kubernetes/secrets/kube-ca.crt"
   cluster-signing-key-file:
   - "/etc/kubernetes/secrets/kube-ca.key"
+  secure-port:
+  - "10257"
   port:
   - "0"
   {{if .ClusterCIDR }}

--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -30,8 +30,10 @@ extendedArguments:
   - "5m" # TODO: set to 220s for AWS like kube-core does
   experimental-cluster-signing-duration:
   - "720h"
+  secure-port:
+  - "10257"
   port:
-  - "10252"
+  - "0"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:

--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -21,9 +21,25 @@ spec:
       requests:
         memory: 200Mi
         cpu: 100m
+    ports:
+      - containerPort: 10257
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 45
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/bindata/v3.11.0/kube-controller-manager/svc.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/svc.yaml
@@ -13,4 +13,4 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8443
+    targetPort: 10257

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -108,8 +108,10 @@ extendedArguments:
   - "5m" # TODO: set to 220s for AWS like kube-core does
   experimental-cluster-signing-duration:
   - "720h"
+  secure-port:
+  - "10257"
   port:
-  - "10252"
+  - "0"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:
@@ -239,9 +241,25 @@ spec:
       requests:
         memory: 200Mi
         cpu: 100m
+    ports:
+      - containerPort: 10257
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 45
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -305,7 +323,7 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8443
+    targetPort: 10257
 `)
 
 func v3110KubeControllerManagerSvcYamlBytes() ([]byte, error) {


### PR DESCRIPTION
@deads2k @sttts lets discuss the probes under this PR...

Right now, we have wrong port on the service and I don't think so we serving the healthz or metrics security from controller manager. Also the `10252` seems odd and we need to decide if we keep it or just move to something else? (8444 before).