### PR TITLE
Use kube-controller-manager as container name for easier debugging

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -9,7 +9,7 @@ metadata:
     revision: "REVISION"
 spec:
   containers:
-  - name: controller-manager
+  - name: kube-controller-manager
     image: ${IMAGE}
     imagePullPolicy: Always
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -226,7 +226,7 @@ metadata:
     revision: "REVISION"
 spec:
   containers:
-  - name: controller-manager
+  - name: kube-controller-manager
     image: ${IMAGE}
     imagePullPolicy: Always
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
"crictl ps -a" does not show pod names. So during disaster recovery full names for the containers is helpful.