### PR TITLE
manifests: add metrics service manifest

### DIFF
--- a/manifests/0000_12_cluster-kube-controller-manager-operator_02_service.yaml
+++ b/manifests/0000_12_cluster-kube-controller-manager-operator_02_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: openshift-cluster-kube-controller-manager-operator-serving-cert
+  labels:
+    app: openshift-cluster-kube-controller-manager-operator
+  name: metrics
+  namespace: openshift-cluster-kube-controller-manager-operator
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: openshift-cluster-kube-controller-manager-operator
+  sessionAffinity: None
+  type: ClusterIP

--- a/manifests/0000_12_cluster-kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_12_cluster-kube-controller-manager-operator_06_deployment.yaml
@@ -41,12 +41,10 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          defaultMode: 400
           secretName: openshift-cluster-kube-controller-manager-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          defaultMode: 440
           name: openshift-cluster-kube-controller-manager-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Add missing `metrics` service (similar to kube apiserver operator). We should already observe the serving certs via library-go, this is just exposing the metrics via service.

Additionally this drops the defaultMode to make this in pair with kube apiserver operator.

/cc @deads2k 
/cc @sttts 