### PR TITLE
add memory request to kube-controller-manager and operator pod

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -17,6 +17,9 @@ spec:
     args:
     - --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
     - --kubeconfig=/etc/kubernetes/static-pod-resources/secrets/controller-manager-kubeconfig/kubeconfig
+    resources:
+      requests:
+        memory: 200Mi
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir

--- a/manifests/0000_12_cluster-kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_12_cluster-kube-controller-manager-operator_06_deployment.yaml
@@ -25,6 +25,9 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         - "-v=4"
+        resources:
+          requests:
+            memory: 50Mi
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -236,6 +236,9 @@ spec:
     args:
     - --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
     - --kubeconfig=/etc/kubernetes/static-pod-resources/secrets/controller-manager-kubeconfig/kubeconfig
+    resources:
+      requests:
+        memory: 200Mi
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir


### PR DESCRIPTION
One in a series of PRs to set memory requests for all control plane and high memory use components.

We are encountering master instability (https://github.com/openshift/installer/pull/408 https://github.com/openshift/installer/pull/785) as the number of components increase because many components run `BestEffort` giving the scheduler no information on pod resource usage.

On a steady state empty cluster, `kube-controller-manager` uses 143MB.

{pod_name="openshift-kube-controller-manager-dev-master-0"} | 142659584

Because it is a control plane component, I'm giving it a buffer and setting to `200Mi`

@deads2k @sttts  @derekwaynecarr



