### PR TITLE
defaultconfig: enable horizontal pod autoscaler

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -24,7 +24,6 @@ extendedArguments:
   - "-ttl" # TODO: this is excluded in kube-core, but not in #21092
   - "-bootstrapsigner"
   - "-tokencleaner"
-  - "-horizontalpodautoscaling"
   node-monitor-grace-period:
   - "5m" # TODO: set to 2m for AWS like kube-core does
   pod-eviction-timeout:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -102,7 +102,6 @@ extendedArguments:
   - "-ttl" # TODO: this is excluded in kube-core, but not in #21092
   - "-bootstrapsigner"
   - "-tokencleaner"
-  - "-horizontalpodautoscaling"
   node-monitor-grace-period:
   - "5m" # TODO: set to 2m for AWS like kube-core does
   pod-eviction-timeout:


### PR DESCRIPTION
This enables the HPA as we have resource metrics API now enabled
due to the addition of k8s prometheus adapter.

xref https://github.com/openshift/cluster-monitoring-operator/pull/174

I am not sure if there is more to set up to make HPA work in the openshift controller manager setup.

cc @brancz @sttts @squat @metalmatze