### PR TITLE
bindata/bootkube: use root-ca.crt for the root-ca-file

### DIFF
--- a/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Namespace }}
 data:
   ca-bundle.crt: |
-    {{ .Assets | load "kube-ca.crt" | indent 4 }}
+    {{ .Assets | load "root-ca.crt" | indent 4 }}
 


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-controller-manager-operator/blob/60ddae3e99ce150f5befb34cbcfe4318577c8bd7/bindata/bootkube/config/bootstrap-config-overrides.yaml already uses `root-ca.crt` for root-ca-file
https://github.com/openshift/cluster-kube-controller-manager-operator/blob/60ddae3e99ce150f5befb34cbcfe4318577c8bd7/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml#L8 is using `kube-ca.crt` that ends up being used as root-ca-file
here https://github.com/openshift/cluster-kube-controller-manager-operator/blob/60ddae3e99ce150f5befb34cbcfe4318577c8bd7/bindata/bootkube/config/config-overrides.yaml#L5

*I am not completely sure that how the root-ca-file gets set in bootstrap and long running phase.* :innocent: 

/cc @aaronlevy @deads2k 