### PR TITLE
Include kube-ca in client-ca bundle

### DIFF
--- a/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml
@@ -6,4 +6,5 @@ metadata:
 data:
   ca-bundle.crt: |
     {{ .Assets | load "root-ca.crt" | indent 4 }}
+    {{ .Assets | load "kube-ca.crt" | indent 4 }}
 


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/110 caused cluster monitoring to break since the kube-ca intermediate is no longer loaded. Until we can ensure that across the board server certificates are distributed with their intermediate signer, we should include it in the ca bundle.
Re: https://jira.coreos.com/browse/MON-498
/cc @s-urbaniak @openshift/sig-auth @abhinavdahiya 