### PR TITLE
Revert "Include kube-ca in client-ca bundle"

### DIFF
--- a/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-kube-controller-manager-client-ca.yaml
@@ -6,5 +6,4 @@ metadata:
 data:
   ca-bundle.crt: |
     {{ .Assets | load "root-ca.crt" | indent 4 }}
-    {{ .Assets | load "kube-ca.crt" | indent 4 }}
 


### PR DESCRIPTION
Reverts openshift/cluster-kube-controller-manager-operator#112

The kube-ca has to be served as part of the server certs. This is the case for the apiserver (otherwise, more would have been broken). For some reason the cadvisor does not serve it, which broke @s-urbaniak's use-case.

I don't think it is right to distribute the kube-ca through the whole cluster as part of some CA bundle. Being part of the server certs is the right approach instead.

Independently, it is questionably why the service account ca.crt is the right CA to be used against the cadvisor in the first place. That CA is meant for the apiserver, and just happens to match other services on the node.

@sjenning can you comment?