### PR TITLE
Use consistently IMAGE_ORG everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The kube-controller-manager operator installs and maintains the kube-controller-
 The operator image version used by the [https://github.com/openshift/installer/blob/master/pkg/asset/ignition/bootstrap/content/bootkube.go#L86](installer) bootstrap phase can be overridden by creating a custom origin-release image pointing to the developer's operator `:latest` image:
 
 ```
-$ IMAGE_REPOSITORY_NAME=sttts make images
+$ IMAGE_ORG=sttts make images
 $ docker push sttts/origin-cluster-kube-controller-manager-operator
 
 $ cd ../cluster-kube-apiserver-operator
-$ IMAGES=cluster-kube-controller-manager-operator IMAGE_REPOSITORY_NAME=sttts make origin-release
+$ IMAGES=cluster-kube-controller-manager-operator IMAGE_ORG=sttts make origin-release
 $ docker push sttts/origin-release:latest
 
 $ cd ../installer


### PR DESCRIPTION
Our build scripts are using `IMAGE_ORG` so I've updated the docs and unified all the places to use the same everywhere. 
/assign @sttts 