### PR TITLE
Support "none" cloudprovider

### DIFF
--- a/pkg/operator/configobservation/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobservation/cloudprovider/observe_cloudprovider.go
@@ -76,6 +76,9 @@ func ObserveCloudProviderNames(genericListers configobserver.Listers, recorder e
 	case platform["libvirt"] != nil:
 		// this means we are using libvirt
 		return observedConfig, errs
+	case platform["none"] != nil:
+		// this means we are using bare metal
+		return observedConfig, errs
 	case platform["aws"] != nil:
 		cloudProvider = "aws"
 	default:

--- a/pkg/operator/configobservation/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobservation/cloudprovider/observe_cloudprovider_test.go
@@ -15,33 +15,53 @@ import (
 )
 
 func TestObserveCloudProviderNames(t *testing.T) {
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := indexer.Add(&corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-config-v1",
-			Namespace: "kube-system",
-		},
-		Data: map[string]string{
-			"install-config": "platform:\n  aws: {}\n",
-		},
-	}); err != nil {
-		t.Fatal(err.Error())
-	}
-	listers := configobservation.Listers{
-		ConfigmapLister: corelistersv1.NewConfigMapLister(indexer),
-	}
-	result, errs := ObserveCloudProviderNames(listers, events.NewInMemoryRecorder("cloud"), map[string]interface{}{})
-	if len(errs) > 0 {
-		t.Fatal(errs)
-	}
-	cloudProvider, _, err := unstructured.NestedSlice(result, "extendedArguments", "cloud-provider")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if e, a := 1, len(cloudProvider); e != a {
-		t.Fatalf("expected len(cloudProvider) == %d, got %d", e, a)
-	}
-	if e, a := "aws", cloudProvider[0]; e != a {
-		t.Errorf("expected cloud-provider=%s, got %s", e, a)
+	cases := []struct {
+		installConfig         string
+		expectedCloudProvider string
+		cloudProviderCount    int
+	}{{
+		installConfig:         "platform:\n  aws: {}\n",
+		expectedCloudProvider: "aws",
+		cloudProviderCount:    1,
+	}, {
+		installConfig:      "platform:\n  libvirt: {}\n",
+		cloudProviderCount: 0,
+	}, {
+		installConfig:      "platform:\n  none: {}\n",
+		cloudProviderCount: 0,
+	}}
+	for idx, c := range cases {
+		t.Logf("Testing case #%d", idx+1)
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		if err := indexer.Add(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-config-v1",
+				Namespace: "kube-system",
+			},
+			Data: map[string]string{
+				"install-config": c.installConfig,
+			},
+		}); err != nil {
+			t.Fatal(err.Error())
+		}
+		listers := configobservation.Listers{
+			ConfigmapLister: corelistersv1.NewConfigMapLister(indexer),
+		}
+		result, errs := ObserveCloudProviderNames(listers, events.NewInMemoryRecorder("cloud"), map[string]interface{}{})
+		if len(errs) > 0 {
+			t.Fatal(errs)
+		}
+		cloudProvider, _, err := unstructured.NestedSlice(result, "extendedArguments", "cloud-provider")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if e, a := c.cloudProviderCount, len(cloudProvider); e != a {
+			t.Fatalf("expected len(cloudProvider) == %d, got %d", e, a)
+		}
+		if c.cloudProviderCount > 0 {
+			if e, a := c.expectedCloudProvider, cloudProvider[0]; e != a {
+				t.Errorf("expected cloud-provider=%s, got %s", e, a)
+			}
+		}
 	}
 }


### PR DESCRIPTION
After https://github.com/openshift/installer/pull/982 was merged BYOR installs use `platform: none`. Our install waits for all CVO operators to complete successfully, but kube-controller-manager-operator fails with this setup:
```
      - apiVersion: config.openshift.io/v1
        kind: ClusterOperator
        metadata:
          creationTimestamp: '2019-01-08T16:39:29Z'
          generation: 1
          name: openshift-kube-controller-manager-operator
          namespace: ''
          resourceVersion: '10227'
          selfLink: /apis/config.openshift.io/v1/clusteroperators/openshift-kube-controller-manager-operator
          uid: f80027da-1363-11e9-85a4-42010af00002
        spec: {}
        status:
          conditions:
          - lastTransitionTime: '2019-01-08T16:49:28Z'
            message: 'ConfigObservationFailing: configmap/cluster-config-v1.kube-system: no recognized cloud provider platform found: map[string]interface {}{"none":map[string]interface {}{}}'
            reason: ConfigObservationFailing
            status: 'True'
            type: Failing
          - lastTransitionTime: '2019-01-08T16:49:28Z'
            message: 3 of 3 nodes are at revision 1
            status: 'True'
            type: Available
          - lastTransitionTime: '2019-01-08T16:49:28Z'
            message: 3 of 3 nodes are at revision 1
            reason: AllNodesAtLatestRevision
            status: 'False'
            type: Progressing
          extension: null
          version: ''
```

This PR adds a support for this platform (as libvirt it doesn't modify `extendedArguments`) and updates tests to verify these three cases. 

~~Don't know how to test that config was not modified, but I could extend the tests later on.~~ Implemented

Verified that it unblocks `platform: none` installs

Fixes #100 