### PR TITLE
stop permafailing status

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -87,6 +87,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		operatorConfigInformers.Kubecontrollermanager().V1alpha1().KubeControllerManagerOperatorConfigs(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		operatorConfigClient.KubecontrollermanagerV1alpha1(),
+		operatorClient,
 		kubeClient,
 		ctx.EventRecorder,
 	)


### PR DESCRIPTION
TargetConfigController was setting a status in response to being unable to set a status and created a situation of permafailing status. In addition to being a dumb thing to do (why try to set the thing you couldn't set), this stuck us in the CVO.

/assign @mfojtik @sanchezl