### PR TITLE
Add OpenStack to ObserveCloudProviderNames

### DIFF
--- a/pkg/operator/configobservation/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobservation/cloudprovider/observe_cloudprovider.go
@@ -81,6 +81,8 @@ func ObserveCloudProviderNames(genericListers configobserver.Listers, recorder e
 		return observedConfig, errs
 	case platform["aws"] != nil:
 		cloudProvider = "aws"
+	case platform["openstack"] != nil:
+		cloudProvider = "openstack"
 	default:
 		errs = append(errs, fmt.Errorf("configmap/cluster-config-v1.kube-system: no recognized cloud provider platform found: %#v", platform))
 		recorder.Warning("ObserveCloudProvidersFailed", fmt.Sprintf("No recognized cloud provider platform found in cloud config: %#v", platform))


### PR DESCRIPTION
Running the operator on OpenStack currently results in "No recognized
cloud provider platform found in cloud config". This adds `openstack`
to the switch statement alongside libvirt and aws.