### PR TITLE
switch to kube-ca as the starting ca.crt

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -2,7 +2,7 @@ apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
   root-ca-file:
-  - "/etc/kubernetes/secrets/root-ca.crt"
+  - "/etc/kubernetes/secrets/kube-ca.crt"
   service-account-private-key-file:
   - "/etc/kubernetes/secrets/service-account.key"
   cluster-signing-cert-file:

--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,8 +1,6 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
-  root-ca-file:
-  - "/var/run/configmaps/client-ca/ca-bundle.crt"
   service-account-private-key-file:
   - "/var/run/secrets/service-account-private-key/service-account.key"
   cluster-signing-cert-file:


### PR DESCRIPTION
This matches what we use from the "real" `sa/ca.rt`.

/assign @sttts @mrogers950 