### PR TITLE
operator: remove openshift prefix from pod name

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: openshift-kube-controller-manager
+  name: kube-controller-manager
   namespace: openshift-kube-controller-manager
   labels:
     app: kube-controller-manager
@@ -9,7 +9,7 @@ metadata:
     revision: "REVISION"
 spec:
   containers:
-  - name: openshift-kube-controller-manager
+  - name: kube-controller-manager-REVISION
     image: ${IMAGE}
     imagePullPolicy: Always
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -115,7 +115,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		WithEvents(ctx.EventRecorder).
 		WithInstaller([]string{"cluster-kube-controller-manager-operator", "installer"}).
 		WithPruning([]string{"cluster-kube-controller-manager-operator", "prune"}, "kube-controller-manager-pod").
-		WithResources(operatorclient.TargetNamespace, "openshift-kube-controller-manager", deploymentConfigMaps, deploymentSecrets).
+		WithResources(operatorclient.TargetNamespace, "kube-controller-manager", deploymentConfigMaps, deploymentSecrets).
 		WithServiceMonitor(dynamicClient).
 		WithVersioning(operatorclient.OperatorNamespace, "kube-controller-manager", versionRecorder).
 		ToControllers()

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -298,7 +298,7 @@ func v3110KubeControllerManagerPodCmYaml() (*asset, error) {
 var _v3110KubeControllerManagerPodYaml = []byte(`apiVersion: v1
 kind: Pod
 metadata:
-  name: openshift-kube-controller-manager
+  name: kube-controller-manager
   namespace: openshift-kube-controller-manager
   labels:
     app: kube-controller-manager
@@ -306,7 +306,7 @@ metadata:
     revision: "REVISION"
 spec:
   containers:
-  - name: openshift-kube-controller-manager
+  - name: kube-controller-manager-REVISION
     image: ${IMAGE}
     imagePullPolicy: Always
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
We need https://github.com/openshift/installer/pull/1253 to support this transition.

In addition to changing the pod names, this also add revision suffix into pod container name, so it is clear in artifacts which revision the collected logs belonged to.

/hold