### PR TITLE
bindata: add missing apiGroup to leader locking role binding

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/leader-election-rolebinding.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/leader-election-rolebinding.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: kube-system
   name: system:openshift:leader-locking-kube-controller-manager
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: system::leader-locking-kube-controller-manager
 subjects:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -197,6 +197,7 @@ metadata:
   namespace: kube-system
   name: system:openshift:leader-locking-kube-controller-manager
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: system::leader-locking-kube-controller-manager
 subjects:


### PR DESCRIPTION
This log shows that we are stomping the `roleRef` because we missing the required `apiGroup` field there:

`
ERROR: logging before flag.Parse: I0218 12:31:01.805265       1 rbac.go:147] RoleBinding "kube-system/system:openshift:leader-locking-kube-controller-manager" changes: {"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"creationTimestamp":null,"resourceVersion":null,"selfLink":null,"uid":null},"roleRef":{"apiGroup":""},"subjects":[{"kind":"User","name":"system:kube-controller-manager"}]}
`

(ignore extra null fields, fixed in https://github.com/openshift/library-go/pull/244 which is actually useful already ;-)