### PR TITLE
targetconfigcontroller: emit warning when management state is set to unknown value

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -102,11 +102,14 @@ func (c TargetConfigController) sync() error {
 	}
 
 	switch operatorConfig.Spec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
-
 	case operatorv1.Removed:
 		// TODO probably just fail
+		return nil
+	default:
+		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorConfig.Spec.ManagementState)
 		return nil
 	}
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1666635

When operator management state is set to unknown value (because we miss the CR validation), the target controller should not keep managing but emit warning and do nothing.