### PR TITLE
use versionRecorder when writing versions

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -134,7 +134,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		},
 		configClient.ConfigV1(),
 		operatorClient,
-		status.NewVersionGetter(),
+		versionRecorder,
 		ctx.EventRecorder,
 	)
 


### PR DESCRIPTION
embarrassing oversight.  Must have fallen out in one of the many rebases.