### PR TITLE
switch to short lived csr signer for bootstrapping

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -6,9 +6,9 @@ extendedArguments:
   service-account-private-key-file:
   - "/etc/kubernetes/secrets/service-account.key"
   cluster-signing-cert-file:
-  - "/etc/kubernetes/secrets/kube-ca.crt"
+  - "/etc/kubernetes/secrets/kubelet-signer.crt"
   cluster-signing-key-file:
-  - "/etc/kubernetes/secrets/kube-ca.key"
+  - "/etc/kubernetes/secrets/kubelet-signer.key"
   secure-port:
   - "10257"
   port:

--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,7 +1,3 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
-  cluster-signing-cert-file:
-  - "/var/run/secrets/cluster-signing-ca/kube-ca.crt"
-  cluster-signing-key-file:
-  - "/var/run/secrets/cluster-signing-ca/kube-ca.key"

--- a/bindata/bootkube/manifests/configmap-initial-kube-controller-manager-csr-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-controller-manager-csr-ca.yaml
@@ -7,4 +7,3 @@ data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}
     {{ .Assets | load "kubelet-signer.crt" | indent 4 }}
-


### PR DESCRIPTION
This comes after https://github.com/openshift/cluster-kube-apiserver-operator/pull/280 and will allow us to remove the original kube-ca.

/assign @mfojtik @sttts 