### PR TITLE
feat(targetconfigcontroller): include service-ca bundle in server account CA bundle

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -13,6 +13,8 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation/cloudprovider"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation/network"
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation/serviceca"
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
 )
 
 type ConfigObserver struct {
@@ -23,6 +25,7 @@ func NewConfigObserver(
 	operatorClient v1helpers.OperatorClient,
 	operatorConfigInformers operatorv1informers.SharedInformerFactory,
 	configinformers configinformers.SharedInformerFactory,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	resourceSyncer resourcesynccontroller.ResourceSyncer,
 	eventRecorder events.Recorder,
 ) *ConfigObserver {
@@ -34,17 +37,20 @@ func NewConfigObserver(
 				InfrastructureLister: configinformers.Config().V1().Infrastructures().Lister(),
 				NetworkLister:        configinformers.Config().V1().Networks().Lister(),
 				ResourceSync:         resourceSyncer,
+				ConfigMapLister:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
 				PreRunCachesSynced: []cache.InformerSynced{
 					configinformers.Config().V1().Infrastructures().Informer().HasSynced,
 					configinformers.Config().V1().Networks().Informer().HasSynced,
+					kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().HasSynced,
 				},
 			},
 			cloudprovider.ObserveCloudProviderNames,
 			network.ObserveClusterCIDRs,
 			network.ObserveServiceClusterIPRanges,
+			serviceca.ObserveServiceCA,
 		),
 	}
-
+	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.EventHandler())
 	operatorConfigInformers.Operator().V1().KubeControllerManagers().Informer().AddEventHandler(c.EventHandler())
 	configinformers.Config().V1().Infrastructures().Informer().AddEventHandler(c.EventHandler())
 	configinformers.Config().V1().Networks().Informer().AddEventHandler(c.EventHandler())

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -1,6 +1,7 @@
 package configobservation
 
 import (
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
@@ -10,6 +11,7 @@ import (
 type Listers struct {
 	InfrastructureLister configlistersv1.InfrastructureLister
 	NetworkLister        configlistersv1.NetworkLister
+	ConfigMapLister      corev1listers.ConfigMapLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced []cache.InformerSynced

--- a/pkg/operator/configobservation/serviceca/observeserviceca.go
+++ b/pkg/operator/configobservation/serviceca/observeserviceca.go
@@ -1,0 +1,62 @@
+package serviceca
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	serviceCAConfigMapName = "service-ca"
+	serviceCABundleKey     = "ca-bundle.crt"
+	serviceCAFilePath      = "/etc/kubernetes/static-pod-resources/configmaps/service-ca/ca-bundle.crt"
+)
+
+// ObserveServiceCA fills in serviceServingCert.CertFile with the path for a configMap containing the service-ca.crt
+func ObserveServiceCA(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+	errs := []error{}
+	prevObservedConfig := map[string]interface{}{}
+
+	topLevelServiceCAFilePath := []string{"serviceServingCert", "certFile"}
+	currentServiceCAFilePath, _, err := unstructured.NestedString(existingConfig, topLevelServiceCAFilePath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if len(currentServiceCAFilePath) > 0 {
+		if err := unstructured.SetNestedField(prevObservedConfig, currentServiceCAFilePath, topLevelServiceCAFilePath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	observedConfig := map[string]interface{}{}
+
+	// add service-ca configmap mount path to ServiceServingCert if configmap exists
+	ca, err := listers.ConfigMapLister.ConfigMaps(operatorclient.TargetNamespace).Get(serviceCAConfigMapName)
+	if errors.IsNotFound(err) {
+		// do nothing because we aren't going to add a path to a missing configmap
+		return observedConfig, errs
+	}
+	if err != nil {
+		// we had an error, return what we had before and exit. this really shouldn't happen
+		return prevObservedConfig, append(errs, err)
+	}
+	if len(ca.Data[serviceCABundleKey]) == 0 {
+		// do nothing because aren't going to add a path to a configmap with no file
+		return observedConfig, errs
+	}
+	// this means we have this configmap and it has values, so wire up the directory
+	if err := unstructured.SetNestedField(observedConfig, serviceCAFilePath, topLevelServiceCAFilePath...); err != nil {
+		recorder.Warningf("ObserveServiceCAConfigMap", "Failed setting serviceCAFile: %v", err)
+		errs = append(errs, err)
+	}
+	if !equality.Semantic.DeepEqual(prevObservedConfig, observedConfig) {
+		recorder.Event("ObserveServiceCAConfigMap", "observed change in config")
+	}
+	return observedConfig, errs
+}

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -36,6 +36,12 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, err
 	}
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "service-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "service-ca"},
+	); err != nil {
+		return nil, err
+	}
 
 	return resourceSyncController, nil
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -85,6 +85,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		operatorClient,
 		operatorConfigInformers,
 		configInformers,
+		kubeInformersForNamespaces,
 		resourceSyncController,
 		ctx.EventRecorder,
 	)
@@ -176,6 +177,7 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "config"},
 	{Name: "controller-manager-kubeconfig"},
 	{Name: "serviceaccount-ca"},
+	{Name: "service-ca"},
 }
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.


### PR DESCRIPTION

### Bug  Report
🐛  Bug 1668825: serviceaccounttoken/service-ca.crt is missing

**Cause:** Missing feature to sync service-ca CA bundle to kube-controller-manager

**Consequence:** In 3.x, the service CA bundle for validating cluster-created
serving certificates was automatically mounted into pods via the ServiceAccount
token secret volume. Workloads that rely upon the service-ca.crt being present
would break in 4.0.

**Fix:** Sync the service CA bundle from the serving-cert-signer to the
kube-controller-manager where it can be injected into serviceaccount token
secrets at admission. The CA bundle will be provided by the service-ca-operator
in a configmap in the "openshift-config-managed" namespace. From there, the
cluster-kube-controller-manager-operator is responsible syncing it to the
kube-controller-manager.

**Result:** 3.x workloads can run on a 4.0 cluster and continue to utilize the
CA bundle found in the serviceaccounttoken/service-ca.crt file for validating
service certificates.

---

### Changes

🔗 AUTH-131: Deprecate SSCS ca in token secrets

1. **Add configmap syncer** to the config-observer controller
   Syncs the service CA bundle provided by the service-ca-operator in the
   "service-ca" configmap in the "openshift-config-managed" namespace to the
   "openshift-kube-controller-manager" namespace where it can be consumed by the
   kube-controller-manager.

2. **Mount the service CA bundle** data from the synced configmap into the
   kube-controller-manager pods at a well-known file location.

3. **Set "serviceServingCert.certFile"** field on the kube-controller-manager
   config to the file where the service-ca bundle is located if present.

### Testing
TODO @ericavonb