### PR TITLE
add all valid signers to csr-controller-ca

### DIFF
--- a/bindata/bootkube/manifests/configmap-initial-kube-controller-manager-csr-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-controller-manager-csr-ca.yaml
@@ -6,4 +6,5 @@ metadata:
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}
+    {{ .Assets | load "kubelet-signer.crt" | indent 4 }}
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -248,6 +248,8 @@ func manageCSRCABundle(lister corev1listers.ConfigMapLister, client corev1client
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-controller-ca"},
 		lister, client, recorder,
+		// TODO until we adopt the csr signer from the installer, we need to include the initial csr signer ca
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-csr-signer-ca"},
 		// include the CA we use to sign CSRs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-signer-ca"},
 		// include the CA we use to sign the cert key pairs from from csr-signer


### PR DESCRIPTION
I think https://github.com/openshift/cluster-kube-apiserver-operator/pull/296 is blocked on not having the expected trust in the csr-controller-ca resulting in an inability to speak to the master kubelets.