### PR TITLE
disable kcm secure serving

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -35,8 +35,8 @@ spec:
       readOnly: true
     livenessProbe:
       httpGet:
-        scheme: HTTPS
-        port: 10257
+        scheme: HTTP
+        port: 10252
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -9,10 +9,6 @@ extendedArguments:
   - "/etc/kubernetes/secrets/kubelet-signer.crt"
   cluster-signing-key-file:
   - "/etc/kubernetes/secrets/kubelet-signer.key"
-  secure-port:
-  - "10257"
-  port:
-  - "0"
   {{if .ClusterCIDR }}
   cluster-cidr: {{range .ClusterCIDR}}
   - {{.}}{{end}}

--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -33,9 +33,9 @@ extendedArguments:
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:
-  - "10257"
-  port:
   - "0"
+  port:
+  - "10252"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:

--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -28,15 +28,15 @@ spec:
       name: resource-dir
     livenessProbe:
       httpGet:
-        scheme: HTTPS
-        port: 10257
+        scheme: HTTP
+        port: 10252
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTPS
-        port: 10257
+        scheme: HTTP
+        port: 10252
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -113,9 +113,9 @@ extendedArguments:
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:
-  - "10257"
-  port:
   - "0"
+  port:
+  - "10252"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:
@@ -323,15 +323,15 @@ spec:
       name: resource-dir
     livenessProbe:
       httpGet:
-        scheme: HTTPS
-        port: 10257
+        scheme: HTTP
+        port: 10252
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTPS
-        port: 10257
+        scheme: HTTP
+        port: 10252
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10


### PR DESCRIPTION
We are not generating serving certs and we do not tolerate not having these certs, so this disables it until we sort out what to do.  This is why the KCM is dying in the rebase.