### PR TITLE
defaultconfig: add --cert-dir in preparation of 1.13

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -35,8 +35,8 @@ spec:
       readOnly: true
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -9,6 +9,10 @@ extendedArguments:
   - "/etc/kubernetes/secrets/kubelet-signer.crt"
   cluster-signing-key-file:
   - "/etc/kubernetes/secrets/kubelet-signer.key"
+  secure-port:
+  - "10257"
+  port:
+  - "0"
   {{if .ClusterCIDR }}
   cluster-cidr: {{range .ClusterCIDR}}
   - {{.}}{{end}}

--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -33,9 +33,9 @@ extendedArguments:
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:
-  - "0"
+  - "10257"
   port:
-  - "10252"
+  - "0"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:

--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -1,6 +1,8 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
+  cert-dir:
+  - "/var/run/kubernetes"
   enable-dynamic-provisioning:
   - "true"
   allocate-node-cidrs:

--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -40,15 +40,15 @@ spec:
       name: resource-dir
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -81,6 +81,8 @@ func v3110KubeControllerManagerCmYaml() (*asset, error) {
 var _v3110KubeControllerManagerDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
+  cert-dir:
+  - "/var/run/kubernetes"
   enable-dynamic-provisioning:
   - "true"
   allocate-node-cidrs:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -113,9 +113,9 @@ extendedArguments:
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:
-  - "0"
+  - "10257"
   port:
-  - "10252"
+  - "0"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:
@@ -335,15 +335,15 @@ spec:
       name: resource-dir
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10


### PR DESCRIPTION
To avoid in-memory certs, compare https://github.com/kubernetes/kubernetes/pull/69884.