### PR TITLE
switch controller manager to secure port

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -35,8 +35,8 @@ spec:
       readOnly: true
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10

--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -33,9 +33,11 @@ extendedArguments:
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:
-  - "0"
+  - "10257"
   port:
-  - "10252"
+  - "0"
+  cert-dir:
+  - "/var/run/kubernetes"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:

--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -15,8 +15,8 @@ spec:
     command: ['/usr/bin/timeout', '30', "/bin/bash", "-c"]
     args:
     - |
-      echo -n "Waiting for port :10252 to be released."
-      while [ -n "$(lsof -ni :10252)" ]; do
+      echo -n "Waiting for port :10257 to be released."
+      while [ -n "$(lsof -ni :10257)" ]; do
         echo -n "."
         sleep 1
       done
@@ -40,15 +40,15 @@ spec:
       name: resource-dir
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -113,9 +113,11 @@ extendedArguments:
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:
-  - "0"
+  - "10257"
   port:
-  - "10252"
+  - "0"
+  cert-dir:
+  - "/var/run/kubernetes"
   root-ca-file:
   - "/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt"
   service-account-private-key-file:
@@ -310,8 +312,8 @@ spec:
     command: ['/usr/bin/timeout', '30', "/bin/bash", "-c"]
     args:
     - |
-      echo -n "Waiting for port :10252 to be released."
-      while [ -n "$(lsof -ni :10252)" ]; do
+      echo -n "Waiting for port :10257 to be released."
+      while [ -n "$(lsof -ni :10257)" ]; do
         echo -n "."
         sleep 1
       done
@@ -335,15 +337,15 @@ spec:
       name: resource-dir
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10252
+        scheme: HTTPS
+        port: 10257
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10


### PR DESCRIPTION
Rebase landed, we should switch the port to secure again. This updates controller manager default config and set the insecure port to 0 and also update the init container to check the secure port.

Also sets the `cert-dir` to `/var/run/kubernetes`.