### PR TITLE
bindata: use default node controller settings

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/defaultconfig.yaml
@@ -26,10 +26,6 @@ extendedArguments:
   - "-ttl" # TODO: this is excluded in kube-core, but not in #21092
   - "-bootstrapsigner"
   - "-tokencleaner"
-  node-monitor-grace-period:
-  - "5m" # TODO: set to 2m for AWS like kube-core does
-  pod-eviction-timeout:
-  - "5m" # TODO: set to 220s for AWS like kube-core does
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -106,10 +106,6 @@ extendedArguments:
   - "-ttl" # TODO: this is excluded in kube-core, but not in #21092
   - "-bootstrapsigner"
   - "-tokencleaner"
-  node-monitor-grace-period:
-  - "5m" # TODO: set to 2m for AWS like kube-core does
-  pod-eviction-timeout:
-  - "5m" # TODO: set to 220s for AWS like kube-core does
   experimental-cluster-signing-duration:
   - "720h"
   secure-port:


### PR DESCRIPTION
@mfojtik @enxebre @derekwaynecarr 

We should not be changing ` node-monitor-grace-period` and `pod-eviction-timeout` from the defaults without cause and there is no cause provided.