### PR TITLE
explicitly set client-ca and aggregator-client-ca to avoid early fatal contact with unready KAS

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/kubeconfig-cert-syncer.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/kubeconfig-cert-syncer.yaml
@@ -1,0 +1,27 @@
+# TODO provide distinct trust between this and the KCM itself
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-controller-cert-syncer-kubeconfig
+  namespace: openshift-kube-controller-manager
+data:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt
+          server: https://localhost:6443
+        name: loopback
+    contexts:
+      - context:
+          cluster: loopback
+          user: kube-controller-manager
+        name: kube-controller-manager
+    current-context: kube-controller-manager
+    kind: Config
+    preferences: {}
+    users:
+      - name: kube-controller-manager
+        user:
+          client-certificate: /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.crt
+          client-key: /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.key

--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -32,6 +32,8 @@ spec:
     - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
     - --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
     - --authorization-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
+    - --client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
+    - --requestheader-client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
     resources:
       requests:
         memory: 200Mi
@@ -41,6 +43,8 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
+    - mountPath: /etc/kubernetes/static-pod-certs
+      name: cert-dir
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -55,6 +59,33 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
+  - name: kube-controller-manager-cert-syncer-REVISION
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-controller-manager-operator", "cert-syncer"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=${POD_NAMESPACE}
+      - --destination-dir=/etc/kubernetes/static-pod-certs
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -63,4 +94,6 @@ spec:
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir
-
+  - hostPath:
+      path: /etc/kubernetes/static-pod-resources/kube-controller-manager-certs
+    name: cert-dir

--- a/cmd/cluster-kube-controller-manager-operator/main.go
+++ b/cmd/cluster-kube-controller-manager-operator/main.go
@@ -13,9 +13,11 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 
-	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/operator"
+	operatorcmd "github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/render"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/resourcegraph"
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator"
+	"github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/prune"
 )
@@ -46,11 +48,12 @@ func NewSSCSCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(operator.NewOperator())
+	cmd.AddCommand(operatorcmd.NewOperator())
 	cmd.AddCommand(render.NewRenderCommand(os.Stderr))
 	cmd.AddCommand(installerpod.NewInstaller())
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
+	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
 
 	return cmd
 }

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -43,5 +43,20 @@ func NewResourceSyncController(
 		return nil, err
 	}
 
+	// kcm is re-using the generic-apiserver, so if we set the client-ca and front-proxy-ca manually, it won't try to load them
+	// dynamically from the cluster and won't crash when API isn't available
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-client-ca"},
+	); err != nil {
+		return nil, err
+	}
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "aggregator-client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-aggregator-client-ca"},
+	); err != nil {
+		return nil, err
+	}
+
 	return resourceSyncController, nil
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -92,6 +92,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 	targetConfigController := targetconfigcontroller.NewTargetConfigController(
 		os.Getenv("IMAGE"),
+		os.Getenv("OPERATOR_IMAGE"),
 		kubeInformersForNamespaces,
 		operatorConfigInformers.Operator().V1().KubeControllerManagers(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
@@ -117,6 +118,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		WithInstaller([]string{"cluster-kube-controller-manager-operator", "installer"}).
 		WithPruning([]string{"cluster-kube-controller-manager-operator", "prune"}, "kube-controller-manager-pod").
 		WithResources(operatorclient.TargetNamespace, "kube-controller-manager", deploymentConfigMaps, deploymentSecrets).
+		WithCerts("kube-controller-manager-certs", CertConfigMaps, CertSecrets).
 		WithServiceMonitor(dynamicClient).
 		WithVersioning(operatorclient.OperatorNamespace, "kube-controller-manager", versionRecorder).
 		ToControllers()
@@ -185,6 +187,7 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "config"},
 	{Name: "controller-manager-kubeconfig"},
 	{Name: "cloud-config", Optional: true},
+	{Name: "kube-controller-cert-syncer-kubeconfig"},
 	{Name: "serviceaccount-ca"},
 	{Name: "service-ca"},
 }
@@ -198,3 +201,10 @@ var deploymentSecrets = []revision.RevisionResource{
 	// this cert is created by the service-ca controller, which doesn't come up until after we are available. this piece of config must be optional.
 	{Name: "serving-cert", Optional: true},
 }
+
+var CertConfigMaps = []revision.RevisionResource{
+	{Name: "aggregator-client-ca"},
+	{Name: "client-ca"},
+}
+
+var CertSecrets = []revision.RevisionResource{}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -40,7 +40,8 @@ import (
 const workQueueKey = "key"
 
 type TargetConfigController struct {
-	targetImagePullSpec string
+	targetImagePullSpec   string
+	operatorImagePullSpec string
 
 	operatorConfigClient operatorv1client.KubeControllerManagersGetter
 	operatorClient       v1helpers.StaticPodOperatorClient
@@ -55,7 +56,7 @@ type TargetConfigController struct {
 }
 
 func NewTargetConfigController(
-	targetImagePullSpec string,
+	targetImagePullSpec, operatorImagePullSpec string,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	operatorConfigInformer operatorv1informers.KubeControllerManagerInformer,
 	namespacedKubeInformers informers.SharedInformerFactory,
@@ -65,7 +66,8 @@ func NewTargetConfigController(
 	eventRecorder events.Recorder,
 ) *TargetConfigController {
 	c := &TargetConfigController{
-		targetImagePullSpec: targetImagePullSpec,
+		targetImagePullSpec:   targetImagePullSpec,
+		operatorImagePullSpec: operatorImagePullSpec,
 
 		configMapLister:      kubeInformersForNamespaces.ConfigMapLister(),
 		secretLister:         kubeInformersForNamespaces.SecretLister(),
@@ -130,6 +132,7 @@ func createTargetConfigController(c TargetConfigController, recorder events.Reco
 
 	directResourceResults := resourceapply.ApplyDirectly(c.kubeClient, c.eventRecorder, v311_00_assets.Asset,
 		"v3.11.0/kube-controller-manager/ns.yaml",
+		"v3.11.0/kube-controller-manager/kubeconfig-cert-syncer.yaml",
 		"v3.11.0/kube-controller-manager/kubeconfig-cm.yaml",
 		"v3.11.0/kube-controller-manager/leader-election-rolebinding.yaml",
 		"v3.11.0/kube-controller-manager/svc.yaml",
@@ -161,7 +164,7 @@ func createTargetConfigController(c TargetConfigController, recorder events.Reco
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/serviceaccount-ca", err))
 	}
-	_, _, err = managePod(c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), recorder, operatorConfig, c.targetImagePullSpec)
+	_, _, err = managePod(c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), recorder, operatorConfig, c.targetImagePullSpec, c.operatorImagePullSpec)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-controller-manager-pod", err))
 	}
@@ -200,15 +203,32 @@ func manageKubeControllerManagerConfig(client corev1client.ConfigMapsGetter, rec
 	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
 }
 
-func managePod(configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorConfig *operatorv1.KubeControllerManager, imagePullSpec string) (*corev1.ConfigMap, bool, error) {
+func managePod(configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorConfig *operatorv1.KubeControllerManager, imagePullSpec, operatorImagePullSpec string) (*corev1.ConfigMap, bool, error) {
 	required := resourceread.ReadPodV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-controller-manager/pod.yaml"))
 	// TODO: If the image pull spec is not specified, the "${IMAGE}" will be used as value and the pod will fail to start.
+	images := map[string]string{
+		"${IMAGE}":          imagePullSpec,
+		"${OPERATOR_IMAGE}": operatorImagePullSpec,
+	}
 	if len(imagePullSpec) > 0 {
-		required.Spec.Containers[0].Image = imagePullSpec
-		if len(required.Spec.InitContainers) > 0 {
-			required.Spec.InitContainers[0].Image = imagePullSpec
+		for i := range required.Spec.Containers {
+			for pat, img := range images {
+				if required.Spec.Containers[i].Image == pat {
+					required.Spec.Containers[i].Image = img
+					break
+				}
+			}
+		}
+		for i := range required.Spec.InitContainers {
+			for pat, img := range images {
+				if required.Spec.InitContainers[i].Image == pat {
+					required.Spec.InitContainers[i].Image = img
+					break
+				}
+			}
 		}
 	}
+
 	var v int
 	switch operatorConfig.Spec.LogLevel {
 	case operatorv1.Normal:


### PR DESCRIPTION
This explicitly sets args to the KCM based on operator managed ca bundles.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1698672