### PR TITLE
Add logging, replicas back to operator manifest

### DIFF
--- a/manifests/0000_12_kube-controller-manager-operator_01_operator.cr.yaml
+++ b/manifests/0000_12_kube-controller-manager-operator_01_operator.cr.yaml
@@ -6,3 +6,8 @@ metadata:
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed
+  imagePullSpec: openshift/origin-hypershift:latest
+  version: 3.11.0
+  logging:
+    level: 2
+  replicas: 2


### PR DESCRIPTION
As https://github.com/openshift/cluster-kube-controller-manager-operator/pull/230/files#r277413054 noticed, we dropped the logging and replicas when moving the manifest from bindata. This adds it back in