### PR TITLE
manifests: bump loglevel of operator to normal

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -30,7 +30,6 @@ spec:
         command: ["cluster-kube-controller-manager-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
-        - "-v=4"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
Avoid operator switching this back to normal. Also make it consistent with kube apiserver operator.