### PR TITLE
Add missing revision suffix when checking for required resources

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 1179af0cd23972727fdc603b97f1f5bec329950c453232435ae2fad89c8e7e36
-updated: 2019-04-30T15:58:17.119541+02:00
+updated: 2019-05-02T11:30:39.542592+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -232,7 +232,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: 77b8897ec79a562e85920134fc65b63300c4d27a
+  version: 168fd4e3c55217ad0042c4ee1ec79e9ce40d5c21
   subpackages:
   - apps
   - apps/v1
@@ -297,7 +297,7 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: 4fd6b40fd308c7c291ab73ac3d6cc73a603fdf96
+  version: 1255cd1766a03ded97b3afdc1990d04be168d967
   subpackages:
   - cmd/crd-schema-gen/generator
   - pkg/assets

--- a/vendor/github.com/openshift/api/security/v1/generated.proto
+++ b/vendor/github.com/openshift/api/security/v1/generated.proto
@@ -189,6 +189,7 @@ message SecurityContextConstraints {
   // for multiple SCCs are equal they will be sorted from most restrictive to
   // least restrictive. If both priorities and restrictions are equal the
   // SCCs will be sorted by name.
+  // +nullable
   optional int32 priority = 2;
 
   // AllowPrivilegedContainer determines if a container can request to be run as privileged.
@@ -197,16 +198,19 @@ message SecurityContextConstraints {
   // DefaultAddCapabilities is the default set of capabilities that will be added to the container
   // unless the pod spec specifically drops the capability.  You may not list a capabiility in both
   // DefaultAddCapabilities and RequiredDropCapabilities.
+  // +nullable
   repeated string defaultAddCapabilities = 4;
 
   // RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
   // are required to be dropped and cannot be added.
+  // +nullable
   repeated string requiredDropCapabilities = 5;
 
   // AllowedCapabilities is a list of capabilities that can be requested to add to the container.
   // Capabilities in this field maybe added at the pod author's discretion.
   // You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
   // To allow all capabilities you may use '*'.
+  // +nullable
   repeated string allowedCapabilities = 6;
 
   // AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
@@ -216,6 +220,7 @@ message SecurityContextConstraints {
   // Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
   // of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
   // To allow no volumes, set to ["none"].
+  // +nullable
   repeated string volumes = 8;
 
   // AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all

--- a/vendor/github.com/openshift/api/security/v1/types.go
+++ b/vendor/github.com/openshift/api/security/v1/types.go
@@ -32,6 +32,7 @@ type SecurityContextConstraints struct {
 	// for multiple SCCs are equal they will be sorted from most restrictive to
 	// least restrictive. If both priorities and restrictions are equal the
 	// SCCs will be sorted by name.
+	// +nullable
 	Priority *int32 `json:"priority" protobuf:"varint,2,opt,name=priority"`
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
@@ -39,14 +40,17 @@ type SecurityContextConstraints struct {
 	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
 	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
 	// DefaultAddCapabilities and RequiredDropCapabilities.
+	// +nullable
 	DefaultAddCapabilities []corev1.Capability `json:"defaultAddCapabilities" protobuf:"bytes,4,rep,name=defaultAddCapabilities,casttype=Capability"`
 	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
 	// are required to be dropped and cannot be added.
+	// +nullable
 	RequiredDropCapabilities []corev1.Capability `json:"requiredDropCapabilities" protobuf:"bytes,5,rep,name=requiredDropCapabilities,casttype=Capability"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
 	// Capabilities in this field maybe added at the pod author's discretion.
 	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	// To allow all capabilities you may use '*'.
+	// +nullable
 	AllowedCapabilities []corev1.Capability `json:"allowedCapabilities" protobuf:"bytes,6,rep,name=allowedCapabilities,casttype=Capability"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	// +k8s:conversion-gen=false
@@ -54,6 +58,7 @@ type SecurityContextConstraints struct {
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
 	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
 	// To allow no volumes, set to ["none"].
+	// +nullable
 	Volumes []FSType `json:"volumes" protobuf:"bytes,8,rep,name=volumes,casttype=FSType"`
 	// AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all
 	// Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -30,6 +30,10 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset(
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-config"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-secret"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-secret", 1)}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-config", 1)}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-secret", 2)}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-config", 2)}},
 	)
 
 	var installerPod *corev1.Pod
@@ -248,6 +252,8 @@ func TestCreateInstallerPod(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset(
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-config"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-secret"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-secret", 1)}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-config", 1)}},
 	)
 
 	var installerPod *corev1.Pod
@@ -898,6 +904,8 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset(
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "test-secret"}},
 				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "test-config"}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: fmt.Sprintf("%s-%d", "test-secret", test.latestAvailableRevision)}},
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: fmt.Sprintf("%s-%d", "test-config", test.latestAvailableRevision)}},
 			)
 			kubeClient.PrependReactor("create", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 				createdPod := action.(ktesting.CreateAction).GetObject().(*corev1.Pod)
@@ -1340,8 +1348,9 @@ func TestEnsureRequiredResources(t *testing.T) {
 		certConfigMaps []revision.RevisionResource
 		certSecrets    []revision.RevisionResource
 
-		configMaps []revision.RevisionResource
-		secrets    []revision.RevisionResource
+		revisionNumber int32
+		configMaps     []revision.RevisionResource
+		secrets        []revision.RevisionResource
 
 		startingResources []runtime.Object
 		expectedErr       string
@@ -1366,7 +1375,7 @@ func TestEnsureRequiredResources(t *testing.T) {
 			secrets: []revision.RevisionResource{
 				{Name: "foo-s"},
 			},
-			expectedErr: "required resources missing: configmaps: ns/foo-cm, secrets: ns/foo-s",
+			expectedErr: "missing required resources: [configmaps: foo-cm-0, secrets: foo-s-0]",
 		},
 		{
 			name: "found-required",
@@ -1377,8 +1386,8 @@ func TestEnsureRequiredResources(t *testing.T) {
 				{Name: "foo-s"},
 			},
 			startingResources: []runtime.Object{
-				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "foo-cm"}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "foo-s"}},
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "foo-cm-0"}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "foo-s-0"}},
 			},
 		},
 		{
@@ -1389,7 +1398,7 @@ func TestEnsureRequiredResources(t *testing.T) {
 			certSecrets: []revision.RevisionResource{
 				{Name: "foo-s"},
 			},
-			expectedErr: "required resources missing: configmaps: ns/foo-cm, secrets: ns/foo-s",
+			expectedErr: "missing required resources: [configmaps: foo-cm, secrets: foo-s]",
 		},
 		{
 			name: "found-required-certs",
@@ -1421,7 +1430,7 @@ func TestEnsureRequiredResources(t *testing.T) {
 				secretsGetter:    client.CoreV1(),
 			}
 
-			actual := c.ensureRequiredResourcesExist()
+			actual := c.ensureRequiredResourcesExist(test.revisionNumber)
 			switch {
 			case len(test.expectedErr) == 0 && actual == nil:
 			case len(test.expectedErr) == 0 && actual != nil:
@@ -1429,7 +1438,7 @@ func TestEnsureRequiredResources(t *testing.T) {
 			case len(test.expectedErr) != 0 && actual == nil:
 				t.Fatal(actual)
 			case len(test.expectedErr) != 0 && actual != nil && !strings.Contains(actual.Error(), test.expectedErr):
-				t.Fatal(actual)
+				t.Fatalf("actual error: %q does not match expected: %q", actual.Error(), test.expectedErr)
 			}
 
 		})

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -165,6 +165,8 @@ func UpdateStatus(client OperatorClient, updateFuncs ...UpdateStatusFunc) (*oper
 		}
 
 		if equality.Semantic.DeepEqual(oldStatus, newStatus) {
+			// We return the newStatus which is a deep copy of oldStatus but with all update funcs applied.
+			updatedOperatorStatus = newStatus
 			return nil
 		}
 


### PR DESCRIPTION
This bump fixes a bug when we checked for resources required to run installer pod without revision suffix. That caused many CI flakes when the early install pods were failing.

/cc @deads2k 
/cc @smarterclayton 