### PR TITLE
static-pod: fail liveness when secrets/csr-signer+serving-cert changes

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -52,6 +52,7 @@ spec:
         - "-ec"
         - |
           find /etc/kubernetes/static-pod-resources/secrets/csr-signer -mmin -1 -exec false {} +
+          find /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key -mmin -1 -exec false {} +
           test $(curl -k --silent --output /dev/stderr --write-out \"%{http_code}\" https://localhost:10257/healthz) = 200"
       initialDelaySeconds: 70
       timeoutSeconds: 10

--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -46,12 +46,16 @@ spec:
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
     livenessProbe:
-      httpGet:
-        scheme: HTTPS
-        port: 10257
-        path: healthz
-      initialDelaySeconds: 45
+      exec:
+        command:
+        - "/bin/bash"
+        - "-ec"
+        - |
+          find /etc/kubernetes/static-pod-resources/secrets/csr-signer -mmin -1 -exec false {} +
+          test $(curl -k --silent --output /dev/stderr --write-out \"%{http_code}\" https://localhost:10257/healthz) = 200"
+      initialDelaySeconds: 70
       timeoutSeconds: 10
+      failureThreshold: 1
     readinessProbe:
       httpGet:
         scheme: HTTPS

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -364,6 +364,7 @@ spec:
         - "-ec"
         - |
           find /etc/kubernetes/static-pod-resources/secrets/csr-signer -mmin -1 -exec false {} +
+          find /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key -mmin -1 -exec false {} +
           test $(curl -k --silent --output /dev/stderr --write-out \"%{http_code}\" https://localhost:10257/healthz) = 200"
       initialDelaySeconds: 70
       timeoutSeconds: 10

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -358,12 +358,16 @@ spec:
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
     livenessProbe:
-      httpGet:
-        scheme: HTTPS
-        port: 10257
-        path: healthz
-      initialDelaySeconds: 45
+      exec:
+        command:
+        - "/bin/bash"
+        - "-ec"
+        - |
+          find /etc/kubernetes/static-pod-resources/secrets/csr-signer -mmin -1 -exec false {} +
+          test $(curl -k --silent --output /dev/stderr --write-out \"%{http_code}\" https://localhost:10257/healthz) = 200"
+      initialDelaySeconds: 70
       timeoutSeconds: 10
+      failureThreshold: 1
     readinessProbe:
       httpGet:
         scheme: HTTPS


### PR DESCRIPTION
We have to dynamically reload client certs in kas, kcm and ks, and the csr signer here in kcm, in order to allow the cert recovery command https://github.com/openshift/cluster-kube-apiserver-operator/pull/444 to recover a broken cluster.

This is a quick and dirty way to archieve this. We plan to replace it with https://github.com/openshift/library-go/pull/392 when it is ready.
