### PR TITLE
proof file change watchdog

### DIFF
--- a/bindata/v3.11.0/kube-controller-manager/pod.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/pod.yaml
@@ -8,6 +8,7 @@ metadata:
     kube-controller-manager: "true"
     revision: "REVISION"
 spec:
+  shareProcessNamespace: true
   initContainers:
   - name: wait-for-host-port
     terminationMessagePolicy: FallbackToLogsOnError
@@ -71,6 +72,11 @@ spec:
             fieldPath: metadata.namespace
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-controller-manager-operator", "cert-syncer"]
     args:
@@ -81,11 +87,36 @@ spec:
       requests:
         memory: 50Mi
         cpu: 10m
+  - name: kube-controller-manager-watchdog-REVISION
+    securityContext:
+      capabilities:
+        add:
+          - SYS_PTRACE
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-controller-manager-operator", "file-watcher-watchdog"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --process-name=hyperkube
+      - --files=/etc/kubernetes/static-pod-certs/secrets/kube-controller-manager-client-cert-key/tls.crt,/etc/kubernetes/static-pod-/secrets/kube-controller-manager-client-cert-key/tls.key,/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.crt,/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key,/etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key/tls.crt,/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/bindata/v3.11.0/kube-controller-manager/watchdog-role.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/watchdog-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: watchdog-kube-controller-manager
+  namespace: openshift-kube-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create

--- a/bindata/v3.11.0/kube-controller-manager/watchdog-rolebinding.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/watchdog-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: system:openshift:watchdog-kube-controller-manager
+roleRef:
+  kind: Role
+  name: watchdog-kube-controller-manager
+subjects:
+  - kind: User
+    name: system:kube-controller-manager

--- a/cmd/cluster-kube-controller-manager-operator/main.go
+++ b/cmd/cluster-kube-controller-manager-operator/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/render"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/resourcegraph"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator"
+	"github.com/openshift/library-go/pkg/operator/watchdog"
+
 	"github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/prune"
@@ -52,6 +54,7 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(render.NewRenderCommand(os.Stderr))
 	cmd.AddCommand(installerpod.NewInstaller())
 	cmd.AddCommand(prune.NewPrune())
+	cmd.AddCommand(watchdog.NewFileWatcherWatchdog())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1179af0cd23972727fdc603b97f1f5bec329950c453232435ae2fad89c8e7e36
-updated: 2019-05-03T14:49:32.86298+02:00
+hash: e7f7f898226d579120e974dbbd6d0f28ef894d406d7f7c215c6f2369f2bdf27f
+updated: 2019-05-07T11:02:35.193947+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -232,7 +232,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: 168fd4e3c55217ad0042c4ee1ec79e9ce40d5c21
+  version: 10f647f62efca0c361334c29499f68ad1a37e266
   subpackages:
   - apps
   - apps/v1
@@ -297,7 +297,8 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: 30efb8b70b661872bd0fd9de4ae37f61815bf161
+  version: 58224374cb6a8ff145e0d063f73b47a7b3ce7cc9
+  repo: https://github.com/mfojtik/library-go
   subpackages:
   - cmd/crd-schema-gen/generator
   - pkg/assets
@@ -345,6 +346,7 @@ imports:
   - pkg/operator/status
   - pkg/operator/unsupportedconfigoverridescontroller
   - pkg/operator/v1helpers
+  - pkg/operator/watchdog
   - pkg/serviceability
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
@@ -358,6 +360,7 @@ imports:
   version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
   - prometheus
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
   subpackages:
@@ -848,7 +851,7 @@ imports:
   - parser
   - types
 - name: k8s.io/klog
-  version: e531227889390a39d9533dde61f590fe9f4b0035
+  version: e88f7305ac70285fef29b8acebb00ba53136eab4
 - name: k8s.io/kube-aggregator
   version: 3e0149950b0e22a3b8579db52bd50e40d0dac10e
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,8 @@ import:
 - package: github.com/openshift/client-go
   version: master
 - package: github.com/openshift/library-go
-  version: master
+  repo: https://github.com/mfojtik/library-go
+  version: suicider
 - package: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
 - package: k8s.io/gengo/args

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -137,6 +137,8 @@ func createTargetConfigController(c TargetConfigController, recorder events.Reco
 		"v3.11.0/kube-controller-manager/leader-election-rolebinding.yaml",
 		"v3.11.0/kube-controller-manager/svc.yaml",
 		"v3.11.0/kube-controller-manager/sa.yaml",
+		"v3.11.0/kube-controller-manager/watchdog-role.yaml",
+		"v3.11.0/kube-controller-manager/watchdog-rolebinding.yaml",
 	)
 	for _, currResult := range directResourceResults {
 		if currResult.Error != nil {

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -320,6 +320,7 @@ metadata:
     kube-controller-manager: "true"
     revision: "REVISION"
 spec:
+  shareProcessNamespace: true
   initContainers:
   - name: wait-for-host-port
     terminationMessagePolicy: FallbackToLogsOnError
@@ -383,6 +384,11 @@ spec:
             fieldPath: metadata.namespace
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-controller-manager-operator", "cert-syncer"]
     args:
@@ -393,11 +399,36 @@ spec:
       requests:
         memory: 50Mi
         cpu: 10m
+  - name: kube-controller-manager-watchdog-REVISION
+    securityContext:
+      capabilities:
+        add:
+          - SYS_PTRACE
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-controller-manager-operator", "file-watcher-watchdog"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --process-name=hyperkube
+      - --files=/etc/kubernetes/static-pod-certs/secrets/kube-controller-manager-client-cert-key/tls.crt,/etc/kubernetes/static-pod-/secrets/kube-controller-manager-client-cert-key/tls.key,/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.crt,/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key,/etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key/tls.crt,/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -10,6 +10,8 @@
 // bindata/v3.11.0/kube-controller-manager/pod.yaml
 // bindata/v3.11.0/kube-controller-manager/sa.yaml
 // bindata/v3.11.0/kube-controller-manager/svc.yaml
+// bindata/v3.11.0/kube-controller-manager/watchdog-role.yaml
+// bindata/v3.11.0/kube-controller-manager/watchdog-rolebinding.yaml
 // DO NOT EDIT!
 
 package v311_00_assets
@@ -512,6 +514,66 @@ func v3110KubeControllerManagerSvcYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v3110KubeControllerManagerWatchdogRoleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: watchdog-kube-controller-manager
+  namespace: openshift-kube-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+`)
+
+func v3110KubeControllerManagerWatchdogRoleYamlBytes() ([]byte, error) {
+	return _v3110KubeControllerManagerWatchdogRoleYaml, nil
+}
+
+func v3110KubeControllerManagerWatchdogRoleYaml() (*asset, error) {
+	bytes, err := v3110KubeControllerManagerWatchdogRoleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-controller-manager/watchdog-role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3110KubeControllerManagerWatchdogRolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: system:openshift:watchdog-kube-controller-manager
+roleRef:
+  kind: Role
+  name: watchdog-kube-controller-manager
+subjects:
+  - kind: User
+    name: system:kube-controller-manager`)
+
+func v3110KubeControllerManagerWatchdogRolebindingYamlBytes() ([]byte, error) {
+	return _v3110KubeControllerManagerWatchdogRolebindingYaml, nil
+}
+
+func v3110KubeControllerManagerWatchdogRolebindingYaml() (*asset, error) {
+	bytes, err := v3110KubeControllerManagerWatchdogRolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-controller-manager/watchdog-rolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -574,6 +636,8 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/kube-controller-manager/pod.yaml":                         v3110KubeControllerManagerPodYaml,
 	"v3.11.0/kube-controller-manager/sa.yaml":                          v3110KubeControllerManagerSaYaml,
 	"v3.11.0/kube-controller-manager/svc.yaml":                         v3110KubeControllerManagerSvcYaml,
+	"v3.11.0/kube-controller-manager/watchdog-role.yaml":               v3110KubeControllerManagerWatchdogRoleYaml,
+	"v3.11.0/kube-controller-manager/watchdog-rolebinding.yaml":        v3110KubeControllerManagerWatchdogRolebindingYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -629,6 +693,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"pod.yaml":                         {v3110KubeControllerManagerPodYaml, map[string]*bintree{}},
 			"sa.yaml":                          {v3110KubeControllerManagerSaYaml, map[string]*bintree{}},
 			"svc.yaml":                         {v3110KubeControllerManagerSvcYaml, map[string]*bintree{}},
+			"watchdog-role.yaml":               {v3110KubeControllerManagerWatchdogRoleYaml, map[string]*bintree{}},
+			"watchdog-rolebinding.yaml":        {v3110KubeControllerManagerWatchdogRolebindingYaml, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/vendor/github.com/openshift/api/authorization/v1/generated.proto
+++ b/vendor/github.com/openshift/api/authorization/v1/generated.proto
@@ -116,9 +116,11 @@ message GroupRestriction {
   // Groups is a list of groups used to match against an individual user's
   // groups. If the user is a member of one of the whitelisted groups, the user
   // is allowed to be bound to a role.
+  // +nullable
   repeated string groups = 1;
 
   // Selectors specifies a list of label selectors over group labels.
+  // +nullable
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labels = 2;
 }
 
@@ -470,9 +472,11 @@ message UserRestriction {
   repeated string users = 1;
 
   // Groups specifies a list of literal group names.
+  // +nullable
   repeated string groups = 2;
 
   // Selectors specifies a list of label selectors over user labels.
+  // +nullable
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labels = 3;
 }
 

--- a/vendor/github.com/openshift/api/authorization/v1/types.go
+++ b/vendor/github.com/openshift/api/authorization/v1/types.go
@@ -493,9 +493,11 @@ type UserRestriction struct {
 	Users []string `json:"users" protobuf:"bytes,1,rep,name=users"`
 
 	// Groups specifies a list of literal group names.
+	// +nullable
 	Groups []string `json:"groups" protobuf:"bytes,2,rep,name=groups"`
 
 	// Selectors specifies a list of label selectors over user labels.
+	// +nullable
 	Selectors []metav1.LabelSelector `json:"labels" protobuf:"bytes,3,rep,name=labels"`
 }
 
@@ -505,9 +507,11 @@ type GroupRestriction struct {
 	// Groups is a list of groups used to match against an individual user's
 	// groups. If the user is a member of one of the whitelisted groups, the user
 	// is allowed to be bound to a role.
+	// +nullable
 	Groups []string `json:"groups" protobuf:"bytes,1,rep,name=groups"`
 
 	// Selectors specifies a list of label selectors over group labels.
+	// +nullable
 	Selectors []metav1.LabelSelector `json:"labels" protobuf:"bytes,2,rep,name=labels"`
 }
 

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -52,10 +52,16 @@ type InfrastructureStatus struct {
 	// For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
 
-	// apiServerURL is a valid URL with scheme(http/https), address and port.
-	// apiServerURL can be used by components like kubelet on machines, to contact the `apisever`
-	// using the infrastructure provider rather than the kubernetes networking.
+	// apiServerURL is a valid URI with scheme(http/https), address and
+	// port.  apiServerURL can be used by components like the web console
+	// to tell users where to find the Kubernetes API.
 	APIServerURL string `json:"apiServerURL"`
+
+	// apiServerInternalURL is a valid URI with scheme(http/https),
+	// address and port.  apiServerInternalURL can be used by components
+	// like kubelets, to contact the Kubernetes API server using the
+	// infrastructure provider rather than Kubernetes networking.
+	APIServerInternalURL string `json:"apiServerInternalURI"`
 }
 
 // PlatformType is a specific supported infrastructure provider.

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -729,11 +729,12 @@ func (InfrastructureSpec) SwaggerDoc() map[string]string {
 }
 
 var map_InfrastructureStatus = map[string]string{
-	"":                    "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
-	"infrastructureName":  "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
-	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
-	"etcdDiscoveryDomain": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
-	"apiServerURL":        "apiServerURL is a valid URL with scheme(http/https), address and port. apiServerURL can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.",
+	"":                     "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
+	"infrastructureName":   "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
+	"platform":             "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+	"etcdDiscoveryDomain":  "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
+	"apiServerURL":         "apiServerURL is a valid URI with scheme(http/https), address and port.  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
+	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme(http/https), address and port.  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
 }
 
 func (InfrastructureStatus) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -11,17 +11,15 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
-	"k8s.io/klog"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-
 	"github.com/openshift/library-go/pkg/config/configdefaults"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/serviceability"
@@ -53,42 +51,22 @@ func NewControllerCommandConfig(componentName string, version version.Info, star
 
 // NewCommand returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
 // leader election and other "normal" behaviors.
-// Deprecated: Use the NewCommandWithContext instead, this is here to be less disturbing for existing usages.
 func (c *ControllerCommandConfig) NewCommand() *cobra.Command {
-	return c.NewCommandWithContext(context.TODO())
-
-}
-
-// NewCommandWithContext returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
-// leader election and other "normal" behaviors.
-// The context passed will be passed down to controller loops and observers and cancelled on SIGTERM and SIGINT signals.
-func (c *ControllerCommandConfig) NewCommandWithContext(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			// boiler plate for the "normal" command
 			rand.Seed(time.Now().UTC().UnixNano())
 			logs.InitLogs()
-
-			// handle SIGTERM and SIGINT by cancelling the context.
-			shutdownCtx, cancel := context.WithCancel(ctx)
-			shutdownHandler := server.SetupSignalHandler()
-			go func() {
-				defer cancel()
-				<-shutdownHandler
-				klog.Infof("Received SIGTERM or SIGINT signal, shutting down controller.")
-			}()
-
 			defer logs.FlushLogs()
 			defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), c.version)()
 			defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
-
 			serviceability.StartProfiler()
 
 			if err := c.basicFlags.Validate(); err != nil {
 				klog.Fatal(err)
 			}
 
-			if err := c.StartController(shutdownCtx); err != nil {
+			if err := c.StartController(context.Background()); err != nil {
 				klog.Fatal(err)
 			}
 		},

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -146,7 +146,6 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 		cloudProvider = "azure"
 	case configv1.VSpherePlatformType:
 		cloudProvider = "vsphere"
-	case configv1.BareMetalPlatformType:
 	case configv1.LibvirtPlatformType:
 	case configv1.OpenStackPlatformType:
 		// TODO(flaper87): Enable this once we've figured out a way to write the cloud provider config in the master nodes

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -56,9 +56,6 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		expected:           "azure",
 		cloudProviderCount: 1,
 	}, {
-		platform:           configv1.BareMetalPlatformType,
-		cloudProviderCount: 0,
-	}, {
 		platform:           configv1.LibvirtPlatformType,
 		cloudProviderCount: 0,
 	}, {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -49,7 +49,7 @@ func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResourc
 	}
 
 	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
-	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from")
 	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
 
 	return cmd
@@ -102,10 +102,6 @@ func (o *CertSyncControllerOptions) Complete() error {
 	kubeConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfigFile, nil)
 	if err != nil {
 		return err
-	}
-
-	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) > 0 {
-		o.Namespace = os.Getenv("POD_NAMESPACE")
 	}
 
 	protoKubeConfig := rest.CopyConfig(kubeConfig)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -215,7 +215,7 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 		for filename, content := range secret.Data {
 			// TODO fix permissions
 			klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
-			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0600); err != nil {
+			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0644); err != nil {
 				return err
 			}
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/watchdog/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/watchdog/cmd.go
@@ -1,0 +1,316 @@
+package watchdog
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/controller/fileobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/retry"
+)
+
+type FileWatcherOptions struct {
+	// ProcessName is the name of the process we will send SIGTERM
+	ProcessName string
+
+	// Files lists all files we want to monitor for changes
+	Files      []string
+	KubeConfig string
+
+	// Namespace to report events to
+	Namespace string
+	recorder  events.Recorder
+
+	// Interval specifies how aggressive we want to be in file checks
+	Interval time.Duration
+
+	// for unit-test to mock getting the process PID
+	findPidByNameFn func(name string) (int, bool, error)
+
+	// for unit-test to mock sending UNIX signals
+	handleSignalFn func(pid int) error
+
+	// for unit-test to mock prefixing files (/proc/PID/root)
+	addProcPrefixToFilesFn func([]string, int) []string
+
+	// lastUsedPid is used to prevent sending multiple SIGTERM's to the same process
+	lastUsedPid int
+}
+
+func NewFileWatcherOptions() *FileWatcherOptions {
+	return &FileWatcherOptions{
+		findPidByNameFn:        FindPidByName,
+		addProcPrefixToFilesFn: addProcPrefixToFiles,
+		handleSignalFn: func(pid int) error {
+			return syscall.Kill(pid, syscall.SIGTERM)
+		},
+	}
+}
+
+// NewFileWatcherWatchdog return the file watcher watchdog command.
+func NewFileWatcherWatchdog() *cobra.Command {
+	o := NewFileWatcherOptions()
+
+	cmd := &cobra.Command{
+		Use:   "file-watcher-watchdog",
+		Short: "Watch files on the disk and kill the specified process on change",
+		Run: func(cmd *cobra.Command, args []string) {
+			klog.V(1).Info(cmd.Flags())
+			klog.V(1).Info(spew.Sdump(o))
+
+			// Handle shutdown
+			termHandler := server.SetupSignalHandler()
+			ctx, shutdown := context.WithCancel(context.TODO())
+			go func() {
+				defer shutdown()
+				<-termHandler
+			}()
+
+			if err := o.Complete(); err != nil {
+				klog.Fatal(err)
+			}
+			if err := o.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+
+			if err := o.Run(ctx); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *FileWatcherOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.ProcessName, "process-name", "", "name of the process to send signal to on file change (eg. 'hyperkube').")
+	fs.StringSliceVar(&o.Files, "files", o.Files, "comma separated list of file names to monitor for changes")
+	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "kubeconfig file or empty")
+	fs.StringVar(&o.Namespace, "namespace", o.Namespace, "namespace to report the watchdog events")
+	fs.DurationVar(&o.Interval, "interval", 5*time.Second, "interval specifying how aggressive the file checks should be")
+}
+
+func (o *FileWatcherOptions) Complete() error {
+	clientConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfig, nil)
+	if err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	// Get event recorder.
+	// Retry on connection errors for 10s, but don't error out, instead fallback to the namespace.
+	var eventTarget *v1.ObjectReference
+	err = retry.RetryOnConnectionErrors(ctx, func(context.Context) (bool, error) {
+		var clientErr error
+		eventTarget, clientErr = events.GetControllerReferenceForCurrentPod(kubeClient, o.Namespace, nil)
+		if clientErr != nil {
+			return false, clientErr
+		}
+		return true, nil
+	})
+	if err != nil {
+		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
+	}
+	o.recorder = events.NewRecorder(kubeClient.CoreV1().Events(o.Namespace), "file-change-watchdog", eventTarget)
+
+	return nil
+}
+
+func (o *FileWatcherOptions) Validate() error {
+	if len(o.ProcessName) == 0 {
+		return fmt.Errorf("process name must be specified")
+	}
+	if len(o.Files) == 0 {
+		return fmt.Errorf("at least one file to observe must be specified")
+	}
+	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) == 0 {
+		return fmt.Errorf("either namespace flag or POD_NAMESPACE environment variable must be specified")
+	}
+	return nil
+}
+
+// runPidObserver runs a loop that observes changes to the PID of the process we send signals after change is detected.
+// When the PID is observed for the first time, the pidObservedCh is closed.
+// When the PID change is observed (after we got initial PID), the shutdown is called (to signal watchdog to restart).
+func (o *FileWatcherOptions) runPidObserver(ctx context.Context, pidObservedCh chan int) {
+	defer close(pidObservedCh)
+	currentPID := 0
+	retries := 0
+	pollErr := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
+		retries++
+		// attempt to find the PID by process name via /proc
+		observedPID, found, err := o.findPidByNameFn(o.ProcessName)
+		if !found || err != nil {
+			klog.Warningf("Unable to determine PID for %q (retry: %d, err: %v)", o.ProcessName, retries, err)
+			return false, nil
+		}
+
+		if currentPID == 0 {
+			currentPID = observedPID
+			// notify runWatchdog when the PID is initially observed (we need the PID to mutate file paths).
+			pidObservedCh <- observedPID
+		}
+
+		// watch for PID changes, when observed restart the observer and wait for the new PID to appear.
+		if currentPID != observedPID {
+			return true, nil
+		}
+
+		return false, nil
+	}, ctx.Done())
+
+	// These are not fatal errors, but we still want to log them out
+	if pollErr != nil && pollErr != wait.ErrWaitTimeout {
+		klog.Warningf("Unexpected error: %v", pollErr)
+	}
+}
+
+// readInitialFileContent reads the content of files specified.
+// This is needed by file observer.
+func readInitialFileContent(files []string) (map[string][]byte, error) {
+	initialContent := map[string][]byte{}
+	for _, name := range files {
+		// skip files that does not exists (yet)
+		if _, err := os.Stat(name); os.IsNotExist(err) {
+			continue
+		}
+		content, err := ioutil.ReadFile(name)
+		if err != nil {
+			return nil, err
+		}
+		initialContent[name] = content
+	}
+	return initialContent, nil
+}
+
+// addProcPrefixToFiles mutates the file list and prefix every file with /proc/PID/root.
+// With shared pid namespace, we are able to access the target container filesystem via /proc.
+func addProcPrefixToFiles(oldFiles []string, pid int) []string {
+	files := []string{}
+	for _, file := range oldFiles {
+		files = append(files, filepath.Join("/proc", fmt.Sprintf("%d", pid), "root", file))
+	}
+	return files
+}
+
+// Run the main watchdog loop.
+func (o *FileWatcherOptions) Run(ctx context.Context) error {
+	for {
+		{
+			instanceCtx, shutdown := context.WithCancel(ctx)
+			defer shutdown()
+			select {
+			case <-ctx.Done():
+				// exit(0)
+				shutdown()
+				return nil
+			default:
+			}
+			if err := o.runWatchdog(instanceCtx); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// runWatchdog run single instance of watchdog.
+func (o *FileWatcherOptions) runWatchdog(ctx context.Context) error {
+	watchdogCtx, shutdown := context.WithCancel(ctx)
+	defer shutdown()
+
+	// Handle watchdog shutdown
+	go func() {
+		defer shutdown()
+		<-ctx.Done()
+	}()
+
+	pidObservedCh := make(chan int)
+	go o.runPidObserver(watchdogCtx, pidObservedCh)
+
+	// Wait while we get the initial PID for the process
+	klog.Infof("Waiting for process %q PID ...", o.ProcessName)
+	currentPID := <-pidObservedCh
+
+	// Mutate path for specified files as '/proc/PID/root/<original path>'
+	// This means side-car container don't have to duplicate the mounts from main container.
+	// This require shared PID namespace feature.
+	filesToWatch := o.addProcPrefixToFilesFn(o.Files, currentPID)
+	klog.Infof("Watching for changes in: %s", spew.Sdump(filesToWatch))
+
+	// Read initial file content. If shared PID namespace does not work, this will error.
+	initialContent, err := readInitialFileContent(filesToWatch)
+	if err != nil {
+		// TODO: remove this once we get aggregated logging
+		o.recorder.Warningf("FileChangeWatchdogFailed", "Reading initial file content failed: %v", err)
+		return fmt.Errorf("unable to read initial file content: %v", err)
+	}
+
+	o.recorder.Eventf("FileChangeWatchdogStarted", "Started watching files for process %s[%d]", o.ProcessName, currentPID)
+
+	observer, err := fileobserver.NewObserver(o.Interval)
+	if err != nil {
+		o.recorder.Warningf("ObserverFailed", "Failed to start to file observer: %v", err)
+		return fmt.Errorf("unable to start file observer: %v", err)
+	}
+
+	observer.AddReactor(func(file string, action fileobserver.ActionType) error {
+		retries := 0
+		// When file change is observed, don't give up on errors when we fail to send signal, but retry sending
+		// and fail hard if we fail to deliver it. Try 5 times, sleep 1s between attempts.
+		var lastSignalErr error
+		pollErr := wait.PollImmediate(1*time.Second, 5*time.Second, func() (done bool, err error) {
+			// we already signalled this PID to terminate and the process is being gracefully terminated now.
+			// do not send the signal to the same PID twice, but wait for the new PID to appear.
+			if currentPID == o.lastUsedPid {
+				return true, nil
+			}
+			defer func() {
+				shutdown()
+			}()
+			o.recorder.Eventf("FileChangeObserved", "Observed change in file %q, sending SIGINT to %s[%d]", file, o.ProcessName, currentPID)
+			if err := o.handleSignalFn(currentPID); err != nil {
+				retries++
+				// NOTE: Failing to deliver signal means we failed to reload process. This is critical and might lead
+				//       to a process that use out-dated certificates.
+				o.recorder.Warningf("SignalFailed", "Failed to send signal to %s[%d] (retry #%d): %v", o.ProcessName, currentPID, retries, err)
+				lastSignalErr = err
+				return false, nil
+			}
+			o.lastUsedPid = currentPID
+			return true, nil
+		})
+		if pollErr != nil {
+			return lastSignalErr
+		}
+		return nil
+	}, initialContent, filesToWatch...)
+
+	go observer.Run(watchdogCtx.Done())
+
+	<-watchdogCtx.Done()
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/watchdog/cmd_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/watchdog/cmd_test.go
@@ -1,0 +1,134 @@
+package watchdog
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+)
+
+func TestPidObserver(t *testing.T) {
+	var currentPIDMutex = sync.Mutex{}
+	currentPID := 1
+
+	getProcessPIDByName := func(name string) (int, bool, error) {
+		currentPIDMutex.Lock()
+		defer currentPIDMutex.Unlock()
+		return currentPID, true, nil
+	}
+
+	watcher := &FileWatcherOptions{
+		findPidByNameFn: getProcessPIDByName,
+	}
+
+	pidObservedCh := make(chan int)
+	monitorTerminated := make(chan struct{})
+
+	go func() {
+		defer close(monitorTerminated)
+		watcher.runPidObserver(context.TODO(), pidObservedCh)
+	}()
+
+	// We should receive the initial PID
+	select {
+	case pid := <-pidObservedCh:
+		if pid != 1 {
+			t.Fatalf("expected PID 1, got %d", pid)
+		}
+		t.Log("initial PID observed")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout (observing initial PID)")
+	}
+
+	// We changed the PID, the monitor should gracefully terminate
+	currentPIDMutex.Lock()
+	currentPID = 10
+	currentPIDMutex.Unlock()
+
+	select {
+	case <-monitorTerminated:
+		t.Log("monitor successfully terminated")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout (terminating monitor)")
+	}
+}
+
+func TestWatchdogRun(t *testing.T) {
+	signalRecv := make(chan int)
+
+	// Make temporary file we are going to watch and write changes
+	testDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+	if err := ioutil.WriteFile(filepath.Join(testDir, "testfile"), []byte("starting"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &FileWatcherOptions{
+		ProcessName: "test",
+		Files:       []string{filepath.Join(testDir, "testfile")},
+		handleSignalFn: func(pid int) error {
+			signalRecv <- pid
+			return nil
+		},
+		findPidByNameFn: func(name string) (int, bool, error) {
+			return 10, true, nil
+		},
+		addProcPrefixToFilesFn: func(files []string, i int) []string {
+			return files
+		},
+		Interval: 200 * time.Millisecond,
+		recorder: eventstesting.NewTestingEventRecorder(t),
+	}
+
+	// commandCtx is context used for the Run() method
+	commandCtx, shutdown := context.WithTimeout(context.TODO(), 1*time.Minute)
+	defer shutdown()
+
+	commandTerminatedCh := make(chan struct{})
+	go func() {
+		defer close(commandTerminatedCh)
+		if err := opts.Run(commandCtx); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give file watcher time to observe the file
+	time.Sleep(1 * time.Second)
+
+	// Modify the monitored file
+	if err := ioutil.WriteFile(filepath.Join(testDir, "testfile"), []byte("changed"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case pid := <-signalRecv:
+		if pid != 10 {
+			t.Errorf("expected received PID to be 10, got %d", pid)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("timeout (waiting for PID)")
+	}
+
+	select {
+	case <-commandTerminatedCh:
+		t.Fatal("run command is not expected to terminate")
+	default:
+	}
+
+	// Test the shutdown sequence
+	shutdown()
+	select {
+	case <-commandTerminatedCh:
+	case <-time.After(20 * time.Second):
+		t.Fatal("run command failed to terminate")
+	}
+
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/watchdog/proc.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/watchdog/proc.go
@@ -1,0 +1,57 @@
+package watchdog
+
+import (
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"syscall"
+)
+
+// FindPidByName find the process name specified by name and return the PID of that process.
+// If the process is not found, the bool is false.
+// NOTE: This require container with shared process namespace (if run as side-car).
+func FindPidByName(name string) (int, bool, error) {
+	files, err := ioutil.ReadDir("/proc")
+	if err != nil {
+		return 0, false, err
+	}
+	// sort means we start with the directories with numbers
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() < files[j].Name()
+	})
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		// only scan process directories (eg. /proc/1234)
+		pid, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+		// read the /proc/123/exe symlink that points to a process
+		linkTarget := readlink(filepath.Join("/proc", file.Name(), "exe"))
+		if path.Base(linkTarget) != name {
+			continue
+		}
+		return pid, true, nil
+	}
+	return 0, false, nil
+}
+
+// readlink is copied from the os.Readlink() but does not return error when the target path does not exists.
+// This is used to read broken links as in case of share PID namespace, the /proc/1/exe points to a binary
+// that does not exists from the source container.
+func readlink(name string) string {
+	for l := 128; ; l *= 2 {
+		b := make([]byte, l)
+		n, _ := syscall.Readlink(name, b)
+		if n < 0 {
+			n = 0
+		}
+		if n < l {
+			return string(b[0:n])
+		}
+	}
+}

--- a/vendor/k8s.io/klog/klog.go
+++ b/vendor/k8s.io/klog/klog.go
@@ -418,7 +418,7 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
 	flagset.Var(&logging.verbosity, "v", "number for the log level verbosity")
 	flagset.BoolVar(&logging.skipHeaders, "skip_headers", false, "If true, avoid header prefixes in the log messages")
-	flagset.BoolVar(&logging.skipLogHeaders, "skip_log_headers", false, "If true, avoid headers when openning log files")
+	flagset.BoolVar(&logging.skipLogHeaders, "skip_log_headers", false, "If true, avoid headers when opening log files")
 	flagset.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
 	flagset.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flagset.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")


### PR DESCRIPTION
This proves the watchdog works. 

The watchdog monitor these files:
```
/etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.crt
/etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.key
/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.crt
/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key
/etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key/tls.crt
/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key
```

If any of these files change, the watchdog will send SIGTERM signal to the `hyperkube` process (they share namespace)

library-go: https://github.com/openshift/library-go/pull/392