### PR TITLE
bindata/kube-controller-manager: fix cluster-monitoring label

### DIFF
--- a/bindata/bootkube/manifests/00_openshift-kube-controller-manager-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-controller-manager-ns.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
-    openshift.io/cluster-monitoring: "true"
   name: openshift-kube-controller-manager
   labels:
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"

--- a/bindata/v3.11.0/kube-controller-manager/ns.yaml
+++ b/bindata/v3.11.0/kube-controller-manager/ns.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
-    openshift.io/cluster-monitoring: "true"
   name: openshift-kube-controller-manager
   labels:
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -264,10 +264,10 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
-    openshift.io/cluster-monitoring: "true"
   name: openshift-kube-controller-manager
   labels:
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"
 `)
 
 func v3110KubeControllerManagerNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Currently `openshift.io/cluster-monitoring` is applied as an annotation,
it should be a label.

Currently, in a freshly deployed cluster I don't even see the annotation applied though at all. The piece of code that does that (I believe) is here: https://github.com/openshift/cluster-kube-controller-manager-operator/blob/f3b13ef52ab480675cb6a665c1b4746a187db7d7/pkg/operator/targetconfigcontroller/targetconfigcontroller.go#L134

Let's see if labels get propagated successfully.

/assign @soltysh @mfojtik 