### PR TITLE
brings back managementState field validation

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -53,6 +53,7 @@ spec:
             managementState:
               description: managementState indicates whether and how the operator
                 should manage the component
+              pattern: ^(Managed|Unmanaged|Force|Removed)$
               type: string
             observedConfig:
               description: observedConfig holds a sparse config that controller has

--- a/manifests/0000_25_kube-controller-manager-operator_01_config.crd.yaml-merge-patch
+++ b/manifests/0000_25_kube-controller-manager-operator_01_config.crd.yaml-merge-patch
@@ -1,0 +1,10 @@
+# this file can be removed once we switch to v0.2 of crd generator
+# see: https://github.com/openshift/cluster-kube-scheduler-operator/pull/148
+spec:
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            managementState:
+              pattern: "^(Managed|Unmanaged|Force|Removed)$"


### PR DESCRIPTION
it was removed in https://github.com/openshift/cluster-kube-controller-manager-operator/commit/ec46b3e62d77e12ae80f2d3c0467707e22c5dac8#diff-e9fad36abe07802cd4c4d9e1cc7c0cc1