### PR TITLE
bindata/bootkube: use loopback kubeconfig to talk to API

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -19,7 +19,7 @@ spec:
       - containerPort: 10257
     command: ["/bin/bash", "-c"]
     args:
-    - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }} --kubeconfig=/etc/kubernetes/secrets/kubeconfig-loopback
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -10,9 +10,9 @@ extendedArguments:
   cluster-signing-key-file:
   - "/etc/kubernetes/secrets/kubelet-signer.key"
   authentication-kubeconfig:
-  - "/etc/kubernetes/secrets/kubeconfig"
+  - "/etc/kubernetes/secrets/kubeconfig-loopback"
   authorization-kubeconfig:
-  - "/etc/kubernetes/secrets/kubeconfig"
+  - "/etc/kubernetes/secrets/kubeconfig-loopback"
   {{if .ClusterCIDR }}
   cluster-cidr: {{range .ClusterCIDR}}
   - {{.}}{{end}}


### PR DESCRIPTION
This code modifies cluster-kube-controller-manager-operator to use a kubeconfig configured for localhost API access. 

This is necessary due to a limitation with Azure internal load balancers. See limitation #2 here: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview#limitations

"Unlike public Load Balancers which provide outbound connections when transitioning from private IP addresses inside the virtual network to public IP addresses, internal Load Balancers do not translate outbound originated connections to the frontend of an internal Load Balancer as both are in private IP address space. This avoids potential for SNAT port exhaustion inside unique internal IP address space where translation is not required. The side effect is that if an outbound flow from a VM in the backend pool attempts a flow to frontend of the internal Load Balancer in which pool it resides and is mapped back to itself, both legs of the flow don't match and the flow will fail."

kubeconfig-loopback is generated by the installer.

https://jira.coreos.com/browse/CORS-1094