### PR TITLE
wire CSR signer to a cert-synced certificates for update

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/defaultconfig.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/defaultconfig.yaml
@@ -39,9 +39,9 @@ extendedArguments:
   service-account-private-key-file:
   - "/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key"
   cluster-signing-cert-file:
-  - "/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.crt"
+  - "/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.crt"
   cluster-signing-key-file:
-  - "/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key"
+  - "/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.key"
   kube-api-qps:
   - "150" # this is a historical values
   kube-api-burst:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -191,4 +191,6 @@ var CertConfigMaps = []revision.RevisionResource{
 	{Name: "client-ca"},
 }
 
-var CertSecrets = []revision.RevisionResource{}
+var CertSecrets = []revision.RevisionResource{
+	{Name: "csr-signer"},
+}

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -119,9 +119,9 @@ extendedArguments:
   service-account-private-key-file:
   - "/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key"
   cluster-signing-cert-file:
-  - "/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.crt"
+  - "/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.crt"
   cluster-signing-key-file:
-  - "/etc/kubernetes/static-pod-resources/secrets/csr-signer/tls.key"
+  - "/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.key"
   kube-api-qps:
   - "150" # this is a historical values
   kube-api-burst:


### PR DESCRIPTION
Wiring a cert-syncer to https://github.com/openshift/origin/pull/23717 so that it's updated regardless of whether the operator is running and it can work without a rollout.