### PR TITLE
add non-MITM proxy support

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/configobserver/proxy"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -47,6 +48,7 @@ func NewConfigObserver(
 				FeatureGateLister_:    configinformers.Config().V1().FeatureGates().Lister(),
 				InfrastructureLister_: configinformers.Config().V1().Infrastructures().Lister(),
 				NetworkLister:         configinformers.Config().V1().Networks().Lister(),
+				ProxyLister_:          configinformers.Config().V1().Proxies().Lister(),
 
 				ResourceSync:    resourceSyncer,
 				ConfigMapLister: kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
@@ -59,6 +61,7 @@ func NewConfigObserver(
 					configinformers.Config().V1().FeatureGates().Informer().HasSynced,
 					configinformers.Config().V1().Infrastructures().Informer().HasSynced,
 					configinformers.Config().V1().Networks().Informer().HasSynced,
+					configinformers.Config().V1().Proxies().Informer().HasSynced,
 				),
 			},
 			cloudprovider.NewCloudProviderObserver(
@@ -68,6 +71,7 @@ func NewConfigObserver(
 			featuregates.NewObserveFeatureFlagsFunc(nil, []string{"extendedArguments", "feature-gates"}),
 			network.ObserveClusterCIDRs,
 			network.ObserveServiceClusterIPRanges,
+			proxy.NewProxyObserveFunc([]string{"targetconfigcontroller", "proxy"}),
 			serviceca.ObserveServiceCA,
 			clustername.ObserveInfraID,
 		),
@@ -82,6 +86,7 @@ func NewConfigObserver(
 	configinformers.Config().V1().FeatureGates().Informer().AddEventHandler(c.EventHandler())
 	configinformers.Config().V1().Infrastructures().Informer().AddEventHandler(c.EventHandler())
 	configinformers.Config().V1().Networks().Informer().AddEventHandler(c.EventHandler())
+	configinformers.Config().V1().Proxies().Informer().AddEventHandler(c.EventHandler())
 
 	return c
 }

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -15,6 +15,7 @@ type Listers struct {
 	FeatureGateLister_    configlistersv1.FeatureGateLister
 	InfrastructureLister_ configlistersv1.InfrastructureLister
 	NetworkLister         configlistersv1.NetworkLister
+	ProxyLister_          configlistersv1.ProxyLister
 	ConfigMapLister       corev1listers.ConfigMapLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
@@ -27,6 +28,10 @@ func (l Listers) InfrastructureLister() configlistersv1.InfrastructureLister {
 
 func (l Listers) FeatureGateLister() configlistersv1.FeatureGateLister {
 	return l.FeatureGateLister_
+}
+
+func (l Listers) ProxyLister() configlistersv1.ProxyLister {
+	return l.ProxyLister_
 }
 
 func (l Listers) ResourceSyncer() resourcesynccontroller.ResourceSyncer {


### PR DESCRIPTION
Equivalent of https://github.com/openshift/cluster-kube-apiserver-operator/pull/530 for kube-controller-manager.  It's probably worth it to de-dupe the envvar creation itself.