### PR TITLE
move rbac for cluster-policy-controller leader lock to kcm-o

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml
@@ -1,19 +1,22 @@
-# This rolebinding binds role for creation of leader lock configmap for upgrades 4.2-> 4.3
+# This role is necessary to create leader lock configmap for upgrades 4.2-> 4.3
 # cluster-policy-controller is split from openshift-controller-manager in 4.3
 # leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
 # cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
-# The locks, role, and rolebinding can be removed in 4.4
+# The lock, role, and rolebinding can be removed in 4.4
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
   namespace: openshift-kube-controller-manager
   name: system:openshift:leader-election-lock-cluster-policy-controller
-roleRef:
-  kind: Role
-  name: system:openshift:leader-election-lock-cluster-policy-controller
-subjects:
-- kind: User
-  name: system:kube-controller-manager
-- kind: ServiceAccount
-  name: namespace-security-allocation-controller
-  namespace: openshift-infra
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -179,6 +179,8 @@ func createTargetConfigController(c TargetConfigController, recorder events.Reco
 		"v4.1.0/kube-controller-manager/kubeconfig-cert-syncer.yaml",
 		"v4.1.0/kube-controller-manager/kubeconfig-cm.yaml",
 		"v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml",
+		"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml",
+		"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml",
 		"v4.1.0/kube-controller-manager/svc.yaml",
 		"v4.1.0/kube-controller-manager/sa.yaml",
 	)

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -6,6 +6,7 @@
 // bindata/v4.1.0/kube-controller-manager/defaultconfig.yaml
 // bindata/v4.1.0/kube-controller-manager/kubeconfig-cert-syncer.yaml
 // bindata/v4.1.0/kube-controller-manager/kubeconfig-cm.yaml
+// bindata/v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml
 // bindata/v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml
 // bindata/v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml
 // bindata/v4.1.0/kube-controller-manager/ns.yaml
@@ -285,17 +286,64 @@ func v410KubeControllerManagerKubeconfigCmYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+var _v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml = []byte(`# This role is necessary to create leader lock configmap for upgrades 4.2-> 4.3
+# cluster-policy-controller is split from openshift-controller-manager in 4.3
+# leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
+# cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
+# The lock, role, and rolebinding can be removed in 4.4
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: system:openshift:leader-election-lock-cluster-policy-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+`)
+
+func v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYamlBytes() ([]byte, error) {
+	return _v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml, nil
+}
+
+func v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml() (*asset, error) {
+	bytes, err := v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml = []byte(`# This rolebinding binds role for creation of leader lock configmap for upgrades 4.2-> 4.3
+# cluster-policy-controller is split from openshift-controller-manager in 4.3
+# leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
+# cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
+# The locks, role, and rolebinding can be removed in 4.4
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: openshift-kube-controller-manager
-  name: system:openshift:leader-lock-cluster-policy-controller
+  name: system:openshift:leader-election-lock-cluster-policy-controller
 roleRef:
   kind: Role
-  name: system:openshift:leader-locking-cluster-policy-controller
+  name: system:openshift:leader-election-lock-cluster-policy-controller
 subjects:
 - kind: User
   name: system:kube-controller-manager
+- kind: ServiceAccount
+  name: namespace-security-allocation-controller
+  namespace: openshift-infra
 `)
 
 func v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYamlBytes() ([]byte, error) {
@@ -666,6 +714,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v4.1.0/kube-controller-manager/defaultconfig.yaml":                                         v410KubeControllerManagerDefaultconfigYaml,
 	"v4.1.0/kube-controller-manager/kubeconfig-cert-syncer.yaml":                                v410KubeControllerManagerKubeconfigCertSyncerYaml,
 	"v4.1.0/kube-controller-manager/kubeconfig-cm.yaml":                                         v410KubeControllerManagerKubeconfigCmYaml,
+	"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml":        v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml,
 	"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml": v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml,
 	"v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml":                           v410KubeControllerManagerLeaderElectionRolebindingYaml,
 	"v4.1.0/kube-controller-manager/ns.yaml":                                                    v410KubeControllerManagerNsYaml,
@@ -724,6 +773,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"defaultconfig.yaml":                                         {v410KubeControllerManagerDefaultconfigYaml, map[string]*bintree{}},
 			"kubeconfig-cert-syncer.yaml":                                {v410KubeControllerManagerKubeconfigCertSyncerYaml, map[string]*bintree{}},
 			"kubeconfig-cm.yaml":                                         {v410KubeControllerManagerKubeconfigCmYaml, map[string]*bintree{}},
+			"leader-election-cluster-policy-controller-role.yaml":        {v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml, map[string]*bintree{}},
 			"leader-election-cluster-policy-controller-rolebinding.yaml": {v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml, map[string]*bintree{}},
 			"leader-election-rolebinding.yaml":                           {v410KubeControllerManagerLeaderElectionRolebindingYaml, map[string]*bintree{}},
 			"ns.yaml":                                                    {v410KubeControllerManagerNsYaml, map[string]*bintree{}},


### PR DESCRIPTION
This PR adds role and rolebinding necessary for creating lease leader lock during upgrades from 4.2 -> 4.3, with split of quota and security controllers from openshift-controller-manager to cluster-policy-controller.  

* PR to remove role/rolebinding from cluster-openshift-controller-manager-operator: https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/125
* this blocks https://github.com/openshift/openshift-controller-manager/pull/37

@deads2k 