### PR TITLE
watch for changes to input secrets from the operator namespace

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -78,7 +78,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		os.Getenv("OPERATOR_IMAGE"),
 		os.Getenv("CLUSTER_POLICY_CONTROLLER_IMAGE"),
 		kubeInformersForNamespaces,
-		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		operatorClient,
 		kubeClient,
 		ctx.EventRecorder,


### PR DESCRIPTION
`oc -n openshift-kube-controller-manager get secrets csr-signer -oyaml` is based on `oc -n openshift-kube-controller-manager-operator get secrets  -oyaml csr-signer` (notice the different namespaces).  This makes sense because the operator has do some pre-processing.  The targetconfigcontroller which produces the kcm secret from the kcmo secret didn't have a watch on kcmo secrets.  This means that when the kcmo secrets are deleted and recreated, the kcm secret is not guaranteed to be updated.  This can result in the kcm using an old csr-signer, which results in cluster death.