### PR TITLE
Fix metrics

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
@@ -24,47 +24,4 @@ spec:
   selector:
     matchLabels:
       app: kube-controller-manager-operator
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kube-controller-manager-operator
-  namespace: openshift-kube-controller-manager-operator
-spec:
-  groups:
-  - name: cluster-version
-    rules:
-    - alert: KubeControllerManagerDown
-      annotations:
-        message: KubeControllerManager has disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-controller-manager"} == 1)
-      for: 15m
-      labels:
-        severity: critical
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kube-controller-manager-operator
-  namespace: openshift-kube-controller-manager-operator
-spec:
-  groups:
-  - name: cluster-version
-    rules:
-    - alert: PodDisruptionBudgetAtLimit
-      annotations:
-        message: The pod disruption budget is preventing further disruption to pods because it is at the minimum allowed level.
-      expr: |
-        kube_poddisruptionbudget_status_expected_pods == on(poddisruptionbudget, service) kube_poddisruptionbudget_status_desired_healthy
-      for: 15m
-      labels:
-        severity: warning
-    - alert: PodDisruptionBudgetLimit
-      annotations:
-        message: The pod disruption budget is below the minimum number allowed pods.
-      expr: |
-        kube_poddisruptionbudget_status_expected_pods < on(poddisruptionbudget, service) kube_poddisruptionbudget_status_desired_healthy
-      for: 15m
-      labels:
-        severity: critical
+

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -21,7 +21,8 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      insecureSkipVerify: true
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: kube-controller-manager.openshift-kube-controller-manager.svc
   namespaceSelector:
     matchNames:
     - openshift-kube-controller-manager

--- a/manifests/0000_90_kube-controller-manager-operator_05_alert-kcm-down.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alert-kcm-down.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-controller-manager-operator
+  namespace: openshift-kube-controller-manager-operator
+spec:
+  groups:
+    - name: cluster-version
+      rules:
+        - alert: KubeControllerManagerDown
+          annotations:
+            message: KubeControllerManager has disappeared from Prometheus target discovery.
+          expr: |
+            absent(up{job="kube-controller-manager"} == 1)
+          for: 15m
+          labels:
+            severity: critical

--- a/manifests/0000_90_kube-controller-manager-operator_05_alert-pdb.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alert-pdb.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-controller-manager-operator
+  namespace: openshift-kube-controller-manager-operator
+spec:
+  groups:
+    - name: cluster-version
+      rules:
+        - alert: PodDisruptionBudgetAtLimit
+          annotations:
+            message: The pod disruption budget is preventing further disruption to pods because it is at the minimum allowed level.
+          expr: |
+            kube_poddisruptionbudget_status_expected_pods == on(poddisruptionbudget, service) kube_poddisruptionbudget_status_desired_healthy
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PodDisruptionBudgetLimit
+          annotations:
+            message: The pod disruption budget is below the minimum number allowed pods.
+          expr: |
+            kube_poddisruptionbudget_status_expected_pods < on(poddisruptionbudget, service) kube_poddisruptionbudget_status_desired_healthy
+          for: 15m
+          labels:
+            severity: critical

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,8 @@
 package version
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -34,8 +35,8 @@ func Get() version.Info {
 }
 
 func init() {
-	buildInfo := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	buildInfo := metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
 			Name: "openshift_cluster_kube_controller_manager_operator_build_info",
 			Help: "A metric with a constant '1' value labeled by major, minor, " +
 				"git commit & git version from which OpenShift Cluster Kube Controller Manager was built.",
@@ -44,5 +45,5 @@ func init() {
 	)
 	buildInfo.WithLabelValues(majorFromGit, minorFromGit, commitFromGit, versionFromGit).Set(1)
 
-	prometheus.MustRegister(buildInfo)
+	legacyregistry.MustRegister(buildInfo)
 }


### PR DESCRIPTION
* First commit will make service monitor secure and split the alerts to separate files (lists are evil in CVO)
* Second commit will fix collection of operator version metrics