### PR TITLE
Bug 1744984: Add e2e test for kube controller manager lease configmap deletion

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml
@@ -1,0 +1,17 @@
+# This role is necessary to create leader lock configmap for upgrades 4.2-> 4.3
+# cluster-policy-controller is split from openshift-controller-manager in 4.3
+# leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
+# cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
+# The lock, role, and rolebinding can be removed in 4.4
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: system:openshift:leader-election-lock-kube-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create

--- a/bindata/v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml
@@ -1,0 +1,19 @@
+# This rolebinding binds role for creation of leader lock configmap for upgrades 4.2-> 4.3
+# cluster-policy-controller is split from openshift-controller-manager in 4.3
+# leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
+# cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
+# The locks, role, and rolebinding can be removed in 4.4
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: system:openshift:leader-election-lock-kube-controller-manager
+roleRef:
+  kind: Role
+  name: system:openshift:leader-election-lock-kube-controller-manager
+subjects:
+- kind: User
+  name: system:kube-controller-manager
+- kind: ServiceAccount
+  name: namespace-security-allocation-controller
+  namespace: openshift-infra

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -185,6 +185,8 @@ func createTargetConfigController(c TargetConfigController, recorder events.Reco
 		"v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml",
 		"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml",
 		"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml",
+		"v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml",
+		"v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml",
 		"v4.1.0/kube-controller-manager/svc.yaml",
 		"v4.1.0/kube-controller-manager/sa.yaml",
 	)

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -8,6 +8,8 @@
 // bindata/v4.1.0/kube-controller-manager/kubeconfig-cm.yaml
 // bindata/v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml
 // bindata/v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml
+// bindata/v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml
+// bindata/v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml
 // bindata/v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml
 // bindata/v4.1.0/kube-controller-manager/ns.yaml
 // bindata/v4.1.0/kube-controller-manager/pod-cm.yaml
@@ -361,6 +363,76 @@ func v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYa
 	return a, nil
 }
 
+var _v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYaml = []byte(`# This role is necessary to create leader lock configmap for upgrades 4.2-> 4.3
+# cluster-policy-controller is split from openshift-controller-manager in 4.3
+# leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
+# cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
+# The lock, role, and rolebinding can be removed in 4.4
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: system:openshift:leader-election-lock-kube-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+`)
+
+func v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYamlBytes() ([]byte, error) {
+	return _v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYaml, nil
+}
+
+func v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYaml() (*asset, error) {
+	bytes, err := v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYaml = []byte(`# This rolebinding binds role for creation of leader lock configmap for upgrades 4.2-> 4.3
+# cluster-policy-controller is split from openshift-controller-manager in 4.3
+# leader lock in openshift-controller-manager NamespaceSecurityAllocationController and in ClusterPolicyController
+# cluster-policy-controller container runs in ns openshift-kube-controller-manager static pod
+# The locks, role, and rolebinding can be removed in 4.4
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: system:openshift:leader-election-lock-kube-controller-manager
+roleRef:
+  kind: Role
+  name: system:openshift:leader-election-lock-kube-controller-manager
+subjects:
+- kind: User
+  name: system:kube-controller-manager
+- kind: ServiceAccount
+  name: namespace-security-allocation-controller
+  namespace: openshift-infra
+`)
+
+func v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYamlBytes() ([]byte, error) {
+	return _v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYaml, nil
+}
+
+func v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYaml() (*asset, error) {
+	bytes, err := v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v410KubeControllerManagerLeaderElectionRolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -708,20 +780,22 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"v4.1.0/kube-controller-manager/cluster-policy-controller-cm.yaml":                          v410KubeControllerManagerClusterPolicyControllerCmYaml,
-	"v4.1.0/kube-controller-manager/cm.yaml":                                                    v410KubeControllerManagerCmYaml,
-	"v4.1.0/kube-controller-manager/default-cluster-policy-controller-config.yaml":              v410KubeControllerManagerDefaultClusterPolicyControllerConfigYaml,
-	"v4.1.0/kube-controller-manager/defaultconfig.yaml":                                         v410KubeControllerManagerDefaultconfigYaml,
-	"v4.1.0/kube-controller-manager/kubeconfig-cert-syncer.yaml":                                v410KubeControllerManagerKubeconfigCertSyncerYaml,
-	"v4.1.0/kube-controller-manager/kubeconfig-cm.yaml":                                         v410KubeControllerManagerKubeconfigCmYaml,
-	"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml":        v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml,
-	"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml": v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml,
-	"v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml":                           v410KubeControllerManagerLeaderElectionRolebindingYaml,
-	"v4.1.0/kube-controller-manager/ns.yaml":                                                    v410KubeControllerManagerNsYaml,
-	"v4.1.0/kube-controller-manager/pod-cm.yaml":                                                v410KubeControllerManagerPodCmYaml,
-	"v4.1.0/kube-controller-manager/pod.yaml":                                                   v410KubeControllerManagerPodYaml,
-	"v4.1.0/kube-controller-manager/sa.yaml":                                                    v410KubeControllerManagerSaYaml,
-	"v4.1.0/kube-controller-manager/svc.yaml":                                                   v410KubeControllerManagerSvcYaml,
+	"v4.1.0/kube-controller-manager/cluster-policy-controller-cm.yaml":                                    v410KubeControllerManagerClusterPolicyControllerCmYaml,
+	"v4.1.0/kube-controller-manager/cm.yaml":                                                              v410KubeControllerManagerCmYaml,
+	"v4.1.0/kube-controller-manager/default-cluster-policy-controller-config.yaml":                        v410KubeControllerManagerDefaultClusterPolicyControllerConfigYaml,
+	"v4.1.0/kube-controller-manager/defaultconfig.yaml":                                                   v410KubeControllerManagerDefaultconfigYaml,
+	"v4.1.0/kube-controller-manager/kubeconfig-cert-syncer.yaml":                                          v410KubeControllerManagerKubeconfigCertSyncerYaml,
+	"v4.1.0/kube-controller-manager/kubeconfig-cm.yaml":                                                   v410KubeControllerManagerKubeconfigCmYaml,
+	"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml":                  v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml,
+	"v4.1.0/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml":           v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml,
+	"v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml":        v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYaml,
+	"v4.1.0/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml": v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYaml,
+	"v4.1.0/kube-controller-manager/leader-election-rolebinding.yaml":                                     v410KubeControllerManagerLeaderElectionRolebindingYaml,
+	"v4.1.0/kube-controller-manager/ns.yaml":                                                              v410KubeControllerManagerNsYaml,
+	"v4.1.0/kube-controller-manager/pod-cm.yaml":                                                          v410KubeControllerManagerPodCmYaml,
+	"v4.1.0/kube-controller-manager/pod.yaml":                                                             v410KubeControllerManagerPodYaml,
+	"v4.1.0/kube-controller-manager/sa.yaml":                                                              v410KubeControllerManagerSaYaml,
+	"v4.1.0/kube-controller-manager/svc.yaml":                                                             v410KubeControllerManagerSvcYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -769,18 +843,20 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"kube-controller-manager": {nil, map[string]*bintree{
 			"cluster-policy-controller-cm.yaml": {v410KubeControllerManagerClusterPolicyControllerCmYaml, map[string]*bintree{}},
 			"cm.yaml":                           {v410KubeControllerManagerCmYaml, map[string]*bintree{}},
-			"default-cluster-policy-controller-config.yaml":              {v410KubeControllerManagerDefaultClusterPolicyControllerConfigYaml, map[string]*bintree{}},
-			"defaultconfig.yaml":                                         {v410KubeControllerManagerDefaultconfigYaml, map[string]*bintree{}},
-			"kubeconfig-cert-syncer.yaml":                                {v410KubeControllerManagerKubeconfigCertSyncerYaml, map[string]*bintree{}},
-			"kubeconfig-cm.yaml":                                         {v410KubeControllerManagerKubeconfigCmYaml, map[string]*bintree{}},
-			"leader-election-cluster-policy-controller-role.yaml":        {v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml, map[string]*bintree{}},
-			"leader-election-cluster-policy-controller-rolebinding.yaml": {v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml, map[string]*bintree{}},
-			"leader-election-rolebinding.yaml":                           {v410KubeControllerManagerLeaderElectionRolebindingYaml, map[string]*bintree{}},
-			"ns.yaml":                                                    {v410KubeControllerManagerNsYaml, map[string]*bintree{}},
-			"pod-cm.yaml":                                                {v410KubeControllerManagerPodCmYaml, map[string]*bintree{}},
-			"pod.yaml":                                                   {v410KubeControllerManagerPodYaml, map[string]*bintree{}},
-			"sa.yaml":                                                    {v410KubeControllerManagerSaYaml, map[string]*bintree{}},
-			"svc.yaml":                                                   {v410KubeControllerManagerSvcYaml, map[string]*bintree{}},
+			"default-cluster-policy-controller-config.yaml":                        {v410KubeControllerManagerDefaultClusterPolicyControllerConfigYaml, map[string]*bintree{}},
+			"defaultconfig.yaml":                                                   {v410KubeControllerManagerDefaultconfigYaml, map[string]*bintree{}},
+			"kubeconfig-cert-syncer.yaml":                                          {v410KubeControllerManagerKubeconfigCertSyncerYaml, map[string]*bintree{}},
+			"kubeconfig-cm.yaml":                                                   {v410KubeControllerManagerKubeconfigCmYaml, map[string]*bintree{}},
+			"leader-election-cluster-policy-controller-role.yaml":                  {v410KubeControllerManagerLeaderElectionClusterPolicyControllerRoleYaml, map[string]*bintree{}},
+			"leader-election-cluster-policy-controller-rolebinding.yaml":           {v410KubeControllerManagerLeaderElectionClusterPolicyControllerRolebindingYaml, map[string]*bintree{}},
+			"leader-election-kube-controller-manager-role-kube-system.yaml":        {v410KubeControllerManagerLeaderElectionKubeControllerManagerRoleKubeSystemYaml, map[string]*bintree{}},
+			"leader-election-kube-controller-manager-rolebinding-kube-system.yaml": {v410KubeControllerManagerLeaderElectionKubeControllerManagerRolebindingKubeSystemYaml, map[string]*bintree{}},
+			"leader-election-rolebinding.yaml":                                     {v410KubeControllerManagerLeaderElectionRolebindingYaml, map[string]*bintree{}},
+			"ns.yaml":                                                              {v410KubeControllerManagerNsYaml, map[string]*bintree{}},
+			"pod-cm.yaml":                                                          {v410KubeControllerManagerPodCmYaml, map[string]*bintree{}},
+			"pod.yaml":                                                             {v410KubeControllerManagerPodYaml, map[string]*bintree{}},
+			"sa.yaml":                                                              {v410KubeControllerManagerSaYaml, map[string]*bintree{}},
+			"svc.yaml":                                                             {v410KubeControllerManagerSvcYaml, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2,8 +2,11 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
@@ -20,6 +23,40 @@ func TestOperatorNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = kubeClient.CoreV1().Namespaces().Get(operatorclient.OperatorNamespace, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKCMRecovery(t *testing.T) {
+	// This is an e2e test to verify that KCM can recover from having its lease configmap deleted
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
+	kubeConfig, err := test.NewClientConfigForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to delete the kube controller manager's configmap in kube-system
+	err = kubeClient.CoreV1().ConfigMaps("kube-system").Delete("kube-controller-manager", &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check to see that the configmap then gets recreated
+	err = wait.Poll(time.Second*5, time.Second*300, func() (bool, error) {
+		_, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get("kube-controller-manager", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a work in progress, trying to create a simple e2e that deletes the KCM configmap then attempts to create a replicaset to see if KCM recovered from the deletion, as described here: https://bugzilla.redhat.com/show_bug.cgi?id=1744984