### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: kube-controller-manager-operator
   labels:
     app: kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: kube-controller-manager
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_90_kube-controller-manager-operator_05_alert-kcm-down.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alert-kcm-down.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: kube-controller-manager-operator
   namespace: openshift-kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: cluster-version

--- a/manifests/0000_90_kube-controller-manager-operator_05_alert-pdb.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alert-pdb.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: kube-controller-manager-operator
   namespace: openshift-kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: cluster-version


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252