### PR TITLE
pkg,bindata: Update path to cluster-policy-controller service serving certificate and private key

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/default-cluster-policy-controller-config.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/default-cluster-policy-controller-config.yaml
@@ -5,6 +5,6 @@ kubeClientConfig:
 servingInfo:
   bindAddress: 0.0.0.0:10357
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/serving-cert/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/serving-cert/tls.key
+  certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
+  keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key
 

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -113,8 +113,8 @@ kubeClientConfig:
 servingInfo:
   bindAddress: 0.0.0.0:10357
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/serving-cert/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/serving-cert/tls.key
+  certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
+  keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key
 
 `)
 


### PR DESCRIPTION
cluster-policy-controller is crashing during bootstrap when trying to open the tls.crt file in 4.4:

```
F1113 14:28:52.501846       1 standalone_apiserver.go:119] open /etc/kubernetes/static-pod-resources/serving-cert/tls.crt: no such file or directory
```

The kube-controller-manager uses /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
while the cluter-policy-controller is using /etc/kubernetes/static-pod-resources/serving-cert/tls.crt (without the `/secrets/`).

This should fix issue by updating the path the cluster-policy-controller
is using to the correct location containing the TLS asssets.


/hold @deads2k said this could be a proper bug that needs fixing so putting a
hold in case we need to update the title, do cherry-picks, etc.