### PR TITLE
Specify "bindNetwork: tcp" so controller manager will work on IPv6 single-stack

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/default-cluster-policy-controller-config.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/default-cluster-policy-controller-config.yaml
@@ -4,6 +4,7 @@ kubeClientConfig:
   kubeConfig: /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
 servingInfo:
   bindAddress: 0.0.0.0:10357
+  bindNetwork: tcp
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -112,6 +112,7 @@ kubeClientConfig:
   kubeConfig: /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
 servingInfo:
   bindAddress: 0.0.0.0:10357
+  bindNetwork: tcp
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key


### PR DESCRIPTION
If you say `net.Listen("tcp", "0.0.0.0:10357")`, golang will actually create a dual-stack IPv4/IPv6 listening socket. But for historical reasons (having to do with bad IPv6 compat in older kube I think), we default to passing `"tcp4"` (the default value of `configv1.ServingInfo.BindNetwork`) instead of `"tcp"`, forcing IPv4-only.

There is no reason these days for servers on the pod network to enforce IPv4-only, so this overrides the default for kube-controller-manager.

This will need to be backported to 4.3.

(based on an earlier patch from @russellb )