### PR TITLE
add exclusion annotations to all resources

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_25_kube-controller-manager-operator_01_operator.cr.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_01_operator.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     release.openshift.io/create-only: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: kube-controller-manager-operator
   name: metrics

--- a/manifests/0000_25_kube-controller-manager-operator_03_configmap.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_03_configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   namespace: openshift-kube-controller-manager-operator
   name: kube-controller-manager-operator-config
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/0000_25_kube-controller-manager-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_04_clusterrolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openshift:operator:kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_25_kube-controller-manager-operator_05_serviceaccount.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_05_serviceaccount.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   namespace: openshift-kube-controller-manager-operator
   name: kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"

--- a/manifests/0000_90_kube-controller-manager-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_01_prometheusrole.yaml
@@ -4,6 +4,8 @@ metadata:
   # TODO this should be a clusterrole
   name: prometheus-k8s
   namespace: openshift-kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_kube-controller-manager-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_02_prometheusrolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
@@ -3,6 +3,8 @@ kind: ServiceMonitor
 metadata:
   name: kube-controller-manager-operator
   namespace: openshift-kube-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-kube-controller-manager
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -20,6 +22,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-kube-controller-manager
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -36,6 +40,8 @@ metadata:
     k8s-app: kube-controller-manager
   name: kube-controller-manager
   namespace: openshift-kube-controller-manager
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.