### PR TITLE
bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 	github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e
-	github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8
+	github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e h1:l+fwEFa4Voy
 github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e/go.mod h1:nLJaHFCQ5Mavh98g2ejEnWYFWBMGVdphrKNjLErOn/w=
 github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8 h1:gjmVJ0XiETkdUbVm4Fu5Hg7S9mlXcEuG6DztuQ4KiYM=
 github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
+github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd h1:mkv11mPK5gyP5QCFOi0ebJHETtSWxLGdAblyIriAqQE=
+github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/deps-gomod.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/deps-gomod.mk
@@ -15,11 +15,12 @@ endef
 verify-deps: tmp_dir:=$(shell mktemp -d)
 verify-deps:
 	$(call restore-deps,$(tmp_dir))
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || echo '`go.mod` content is incorrect - did you run `go mod tidy`?'
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || echo '`go.sum` content is incorrect - did you run `go mod tidy`?'
 	@echo $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff
 	@     $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff || ( \
 		echo "ERROR: Content of 'vendor/' directory doesn't match 'go.mod' configuration and the overrides in 'deps.diff'!" && \
+		echo 'Did you run `go mod vendor`?' && \
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
 		exit 1 \
 	)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/node/node_controller.go
@@ -111,7 +111,7 @@ func (c NodeController) sync() error {
 	for _, node := range nodes {
 		for _, con := range node.Status.Conditions {
 			if con.Type == coreapiv1.NodeReady && con.Status != coreapiv1.ConditionTrue {
-				notReadyNodes = append(notReadyNodes, node.Name)
+				notReadyNodes = append(notReadyNodes, fmt.Sprintf("node %q not ready since %s because %s (%s)", node.Name, con.LastTransitionTime, con.Reason, con.Message))
 			}
 		}
 	}
@@ -121,11 +121,11 @@ func (c NodeController) sync() error {
 	if len(notReadyNodes) > 0 {
 		newCondition.Status = operatorv1.ConditionTrue
 		newCondition.Reason = "MasterNodesReady"
-		newCondition.Message = fmt.Sprintf("The master node(s) %q not ready", strings.Join(notReadyNodes, ","))
+		newCondition.Message = fmt.Sprintf("The master nodes not ready: %s", strings.Join(notReadyNodes, ", "))
 	} else {
 		newCondition.Status = operatorv1.ConditionFalse
 		newCondition.Reason = "MasterNodesReady"
-		newCondition.Message = "All master node(s) are ready"
+		newCondition.Message = "All master nodes are ready"
 	}
 
 	oldStatus := &operatorv1.StaticPodOperatorStatus{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8
+# github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib


### PR DESCRIPTION
* openshift/library-go@6c7d7cc3: staticpod: improve node not ready degraded message to include reason and message
* openshift/library-go@0b9c208d: build-machinery: Add human readable messages to go mod verify-deps