### PR TITLE
Bug 1798048: bindata: remove revision suffix from containers

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -34,7 +34,7 @@ spec:
         sleep 1
       done
   containers:
-  - name: kube-controller-manager-REVISION
+  - name: kube-controller-manager
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -76,7 +76,7 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
-  - name: cluster-policy-controller-REVISION
+  - name: cluster-policy-controller
     image: ${CLUSTER_POLICY_CONTROLLER_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -108,7 +108,7 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
-  - name: kube-controller-manager-cert-syncer-REVISION
+  - name: kube-controller-manager-cert-syncer
     env:
       - name: POD_NAME
         valueFrom:
@@ -135,7 +135,7 @@ spec:
         name: resource-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
-  - name: kube-controller-manager-recovery-controller-REVISION
+  - name: kube-controller-manager-recovery-controller
     env:
     - name: POD_NAMESPACE
       valueFrom:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -628,7 +628,7 @@ spec:
         sleep 1
       done
   containers:
-  - name: kube-controller-manager-REVISION
+  - name: kube-controller-manager
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -670,7 +670,7 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
-  - name: cluster-policy-controller-REVISION
+  - name: cluster-policy-controller
     image: ${CLUSTER_POLICY_CONTROLLER_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -702,7 +702,7 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
-  - name: kube-controller-manager-cert-syncer-REVISION
+  - name: kube-controller-manager-cert-syncer
     env:
       - name: POD_NAME
         valueFrom:
@@ -729,7 +729,7 @@ spec:
         name: resource-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
-  - name: kube-controller-manager-recovery-controller-REVISION
+  - name: kube-controller-manager-recovery-controller
     env:
     - name: POD_NAMESPACE
       valueFrom:


### PR DESCRIPTION
We don't need revision suffix as the pod already has revision in label. The original intent was to make it clear which revision we have in artifact logs, but having this suffix makes it harder to debug or to get logs when debugging broken clusters.

Combined with kubernetes/kubernetes#87809 I think we will get into desirable state :-)

/cc @deads2k
/cc @smarterclayton