### PR TITLE
Bug 1802297: Inject kube-controller-manager pods trust stores with trusted ca bundle

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -26,14 +26,19 @@ spec:
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["hyperkube", "kube-controller-manager"]
+    command: ["/bin/bash", "-ec"]
     args:
-    - --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
-    - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-    - --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-    - --authorization-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-    - --client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-    - --requestheader-client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
+        - |
+          if [ -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
+            echo "Copying system trust bundle"
+            cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          fi
+          exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
+            --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+            --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+            --authorization-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+            --client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt \
+            --requestheader-client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
     resources:
       requests:
         memory: 200Mi

--- a/bindata/v4.1.0/kube-controller-manager/trusted-ca-cm.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/trusted-ca-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -188,6 +188,9 @@ var deploymentSecrets = []revision.RevisionResource{
 var CertConfigMaps = []revision.RevisionResource{
 	{Name: "aggregator-client-ca"},
 	{Name: "client-ca"},
+
+	// this is a copy of trusted-ca-bundle CM but with key modified to "tls-ca-bundle.pem" so that we can mount it the way we need
+	{Name: "trusted-ca-bundle", Optional: true},
 }
 
 var CertSecrets = []revision.RevisionResource{

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -293,27 +293,35 @@ func managePod(configMapsGetter corev1client.ConfigMapsGetter, secretsGetter cor
 		}
 	}
 
-	var v int
+	containerArgsWithLoglevel := required.Spec.Containers[0].Args
+	if argsCount := len(containerArgsWithLoglevel); argsCount > 1 {
+		return nil, false, fmt.Errorf("expected only one container argument, got %d", argsCount)
+	}
+	if !strings.Contains(containerArgsWithLoglevel[0], "exec hyperkube kube-controller-manager") {
+		return nil, false, fmt.Errorf("exec hyperkube kube-controller-manager not found in first argument %q", containerArgsWithLoglevel[0])
+	}
+
+	containerArgsWithLoglevel[0] = strings.TrimSpace(containerArgsWithLoglevel[0])
 	switch operatorSpec.LogLevel {
 	case operatorv1.Normal:
-		v = 2
+		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 2)
 	case operatorv1.Debug:
-		v = 4
+		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 4)
 	case operatorv1.Trace:
-		v = 6
+		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 6)
 	case operatorv1.TraceAll:
-		v = 8
+		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 8)
 	default:
-		v = 2
+		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 2)
 	}
-	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", v))
 
 	if _, err := secretsGetter.Secrets(required.Namespace).Get("serving-cert", metav1.GetOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return nil, false, err
 	} else if err == nil {
-		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, "--tls-cert-file=/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt")
-		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, "--tls-private-key-file=/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key")
+		containerArgsWithLoglevel[0] += " --tls-cert-file=/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt"
+		containerArgsWithLoglevel[0] += " --tls-private-key-file=/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key"
 	}
+	containerArgsWithLoglevel[0] = strings.TrimSpace(containerArgsWithLoglevel[0])
 
 	var observedConfig map[string]interface{}
 	if err := yaml.Unmarshal(operatorSpec.ObservedConfig.Raw, &observedConfig); err != nil {

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -14,6 +14,7 @@
 // bindata/v4.1.0/kube-controller-manager/pod.yaml
 // bindata/v4.1.0/kube-controller-manager/sa.yaml
 // bindata/v4.1.0/kube-controller-manager/svc.yaml
+// bindata/v4.1.0/kube-controller-manager/trusted-ca-cm.yaml
 // DO NOT EDIT!
 
 package v411_00_assets
@@ -488,14 +489,19 @@ spec:
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["hyperkube", "kube-controller-manager"]
+    command: ["/bin/bash", "-ec"]
     args:
-    - --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
-    - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-    - --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-    - --authorization-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-    - --client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-    - --requestheader-client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
+        - |
+          if [ -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
+            echo "Copying system trust bundle"
+            cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          fi
+          exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
+            --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+            --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+            --authorization-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+            --client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt \
+            --requestheader-client-ca-file=/etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
     resources:
       requests:
         memory: 200Mi
@@ -631,6 +637,30 @@ func v410KubeControllerManagerSvcYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v410KubeControllerManagerTrustedCaCmYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+`)
+
+func v410KubeControllerManagerTrustedCaCmYamlBytes() ([]byte, error) {
+	return _v410KubeControllerManagerTrustedCaCmYaml, nil
+}
+
+func v410KubeControllerManagerTrustedCaCmYaml() (*asset, error) {
+	bytes, err := v410KubeControllerManagerTrustedCaCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-controller-manager/trusted-ca-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -697,6 +727,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v4.1.0/kube-controller-manager/pod.yaml":                                                             v410KubeControllerManagerPodYaml,
 	"v4.1.0/kube-controller-manager/sa.yaml":                                                              v410KubeControllerManagerSaYaml,
 	"v4.1.0/kube-controller-manager/svc.yaml":                                                             v410KubeControllerManagerSvcYaml,
+	"v4.1.0/kube-controller-manager/trusted-ca-cm.yaml":                                                   v410KubeControllerManagerTrustedCaCmYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -756,6 +787,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"pod.yaml":                                                             {v410KubeControllerManagerPodYaml, map[string]*bintree{}},
 			"sa.yaml":                                                              {v410KubeControllerManagerSaYaml, map[string]*bintree{}},
 			"svc.yaml":                                                             {v410KubeControllerManagerSvcYaml, map[string]*bintree{}},
+			"trusted-ca-cm.yaml":                                                   {v410KubeControllerManagerTrustedCaCmYaml, map[string]*bintree{}},
 		}},
 	}},
 }}


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-kube-controller-manager-operator/pull/325 on to 4.2 release. The pick wasn't clean b/c the bot failed, but it was rather minor problem so I'd consider that semi-clean :wink: 

/assign @stlaz 