### PR TITLE
Bug 1804239: Make csr-signer live-reloaded

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -186,7 +186,6 @@ var deploymentConfigMaps = []revision.RevisionResource{
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
 var deploymentSecrets = []revision.RevisionResource{
-	{Name: "csr-signer"},
 	{Name: "kube-controller-manager-client-cert-key"},
 	{Name: "service-account-private-key"},
 


### PR DESCRIPTION
csr-signer is wired for both live-reload and revisioned, but revisioned refs aren't used. Live reloading went in https://github.com/openshift/origin/pull/24577 . If we live reload we don't want to trigger revision rollout.

/cc @p0lyn0mial @soltysh @deads2k 