### PR TITLE
Bug 1810008: Reload client certs

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/kubeconfig-cm.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/kubeconfig-cm.yaml
@@ -22,5 +22,5 @@ data:
     users:
       - name: kube-controller-manager
         user:
-          client-certificate: /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.crt
-          client-key: /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.key
+          client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-controller-manager-client-cert-key/tls.crt
+          client-key: /etc/kubernetes/static-pod-certs/secrets/kube-controller-manager-client-cert-key/tls.key

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -186,7 +186,6 @@ var deploymentConfigMaps = []revision.RevisionResource{
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
 var deploymentSecrets = []revision.RevisionResource{
-	{Name: "kube-controller-manager-client-cert-key"},
 	{Name: "service-account-private-key"},
 
 	// this cert is created by the service-ca controller, which doesn't come up until after we are available. this piece of config must be optional.
@@ -205,5 +204,6 @@ var CertConfigMaps = []revision.RevisionResource{
 }
 
 var CertSecrets = []revision.RevisionResource{
+	{Name: "kube-controller-manager-client-cert-key"},
 	{Name: "csr-signer"},
 }

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -276,8 +276,8 @@ data:
     users:
       - name: kube-controller-manager
         user:
-          client-certificate: /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.crt
-          client-key: /etc/kubernetes/static-pod-resources/secrets/kube-controller-manager-client-cert-key/tls.key
+          client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-controller-manager-client-cert-key/tls.crt
+          client-key: /etc/kubernetes/static-pod-certs/secrets/kube-controller-manager-client-cert-key/tls.key
 `)
 
 func v410KubeControllerManagerKubeconfigCmYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Client certs needs to be updated by cert-syncer and live reloaded for recovery to work.

/hold
Requires:
 - [x] https://github.com/openshift/origin/pull/24646

/cc @deads2k @soltysh 