### PR TITLE
Bug 1812583: Normalize CPU requests on masters

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -56,7 +56,7 @@ spec:
     resources:
       requests:
         memory: 200Mi
-        cpu: 100m
+        cpu: 80m
     ports:
       - containerPort: 10257
     volumeMounts:
@@ -88,7 +88,7 @@ spec:
     resources:
       requests:
         memory: 200Mi
-        cpu: 100m
+        cpu: 10m
     ports:
       - containerPort: 10357
     volumeMounts:
@@ -131,7 +131,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir
@@ -155,7 +155,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -733,7 +733,7 @@ spec:
     resources:
       requests:
         memory: 200Mi
-        cpu: 100m
+        cpu: 80m
     ports:
       - containerPort: 10257
     volumeMounts:
@@ -765,7 +765,7 @@ spec:
     resources:
       requests:
         memory: 200Mi
-        cpu: 100m
+        cpu: 10m
     ports:
       - containerPort: 10357
     volumeMounts:
@@ -808,7 +808,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir
@@ -832,7 +832,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir


### PR DESCRIPTION
The kcm uses approximately 5% of master CPU in a reasonable medium
sized workload. The kcm can be bursty in certain scenarios.

Given a 1 core per master baseline (since CPU is compressible and
shared), assign the kcm roughly 10% of that core on each master
(1/3 of the kube-apiserver usage).