### PR TITLE
reduce cert rotation scale for csr-signer

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -159,10 +159,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		operatorClient,
 		kubeInformersForNamespaces,
 		cc.EventRecorder,
-		// this is weird, but when we turn down rotation in CI, we go fast enough that kubelets and kas are racing to observe the new signer before the signer is used.
-		// we need to establish some kind of delay or back pressure to prevent the rollout.  This ensures we don't trigger kas restart
-		// during e2e tests for now.
-		certRotationScale*8,
+		certRotationScale,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
with this change, we will check the possibility to test start/stop procedure within minutes instead of waiting for hours. Right now, scaling factor of 8 limits this as `csr-signer` would rotate at a different interval than other control plane certs.