### PR TITLE
Bug 1821680: Sync csr-controller-ca to openshift-config-managed namespace

### DIFF
--- a/pkg/cmd/recoverycontroller/cmd.go
+++ b/pkg/cmd/recoverycontroller/cmd.go
@@ -10,12 +10,12 @@ import (
 	"k8s.io/client-go/pkg/version"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/certrotationcontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/certrotationcontroller"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
 )
 
@@ -110,6 +110,7 @@ func (o *Options) Run(ctx context.Context) error {
 	csrController, err := NewCSRController(
 		kubeClient,
 		kubeInformersForNamespaces,
+		operatorClient,
 		o.controllerContext.EventRecorder,
 	)
 	if err != nil {

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -10,6 +10,13 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
 )
 
+func AddSyncCSRControllerCA(resourceSyncController *resourcesynccontroller.ResourceSyncController) error {
+	return resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-controller-ca"},
+	)
+}
+
 func NewResourceSyncController(
 	operatorConfigClient v1helpers.OperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
@@ -24,10 +31,7 @@ func NewResourceSyncController(
 		v1helpers.CachedConfigMapGetter(configMapsGetter, kubeInformersForNamespaces),
 		eventRecorder,
 	)
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-controller-ca"},
-	); err != nil {
+	if err := AddSyncCSRControllerCA(resourceSyncController); err != nil {
 		return nil, err
 	}
 	if err := resourceSyncController.SyncSecret(


### PR DESCRIPTION
When recovering from expired certificates, the refreshed `csr-controller-ca` configmap needs to be propagated to openshift-config-managed namespace to be consumed by CKAO to trust the new client certs.

/cc @deads2k @soltysh 