### PR TITLE
Bug 1821689: Fix csr-signer update hotloop

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -479,6 +479,7 @@ func ManageCSRSigner(ctx context.Context, lister corev1listers.SecretLister, cli
 			"tls.crt": certBytes,
 			"tls.key": signingKey,
 		},
+		Type: corev1.SecretTypeOpaque,
 	}
 	secret, modified, err := resourceapply.ApplySecret(client, recorder, csrSigner)
 	return secret, 0, modified, err

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -115,6 +115,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-10*time.Minute), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: false,
@@ -125,6 +126,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-10*time.Minute), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "missing-target"},
@@ -138,6 +140,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  5 * time.Minute,
 			expectedChange: false,
@@ -148,6 +151,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-3*time.Minute), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  2 * time.Minute,
 			expectedChange: false,
@@ -158,10 +162,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(1*time.Hour), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       makeCerts(t, time.Now().Add(-10*time.Minute), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  65 * time.Minute,
 			expectedChange: false,
@@ -172,10 +178,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(1*time.Hour), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -186,9 +194,11 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "missing-target"},
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -199,6 +209,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: false,
@@ -209,9 +220,11 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -222,9 +235,11 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -235,10 +250,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -249,6 +266,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       map[string][]byte{"tls.crt": {6, 6, 6}, "tls.key": {6, 6, 6}},
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: false,
@@ -259,10 +277,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
+				Type:       corev1.SecretTypeOpaque,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       map[string][]byte{"tls.crt": {6, 6, 6}, "tls.key": {6, 6, 6}},
+				Type:       corev1.SecretTypeOpaque,
 			},
 			expectedDelay:  0,
 			expectedChange: true,


### PR DESCRIPTION
1. CSR signer changes
2. ApplySecret with the new signer Secret, missing Type
3. kube validation discards the Type and saves it with the old type
4. Update return nil, considered updated (although nothing check is the updated equals desired)
5. On next sync desired != actual, go to `#2`

/cc @deads2k @soltysh 