### PR TITLE
Fix CSR signer Secret type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20200327145400-6efe1ee417e1
 	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae
+	github.com/openshift/library-go v0.0.0-20200408130829-d3cb092fabfd
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/common v0.6.0
 	github.com/spf13/cobra v0.0.5
@@ -26,6 +26,5 @@ require (
 replace (
 	github.com/jteeuwen/go-bindata => github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/stretchr/testify => github.com/stretchr/testify v1.2.2-0.20180319223459-c679ae2cc0cb
-
 	k8s.io/gengo => k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12
 )

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
-github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae h1:QE9zls9gSMcB8LYWi2mFvVaiAcI4ECg6b45/OYHGe9E=
-github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
+github.com/openshift/library-go v0.0.0-20200408130829-d3cb092fabfd h1:J6soCdVvbNpIEP9ugsRjgi1JcjeCPlI4jbGNEMLIOEQ=
+github.com/openshift/library-go v0.0.0-20200408130829-d3cb092fabfd/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -479,7 +479,7 @@ func ManageCSRSigner(ctx context.Context, lister corev1listers.SecretLister, cli
 			"tls.crt": certBytes,
 			"tls.key": signingKey,
 		},
-		Type: corev1.SecretTypeOpaque,
+		Type: corev1.SecretTypeTLS,
 	}
 	secret, modified, err := resourceapply.ApplySecret(client, recorder, csrSigner)
 	return secret, 0, modified, err

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -115,7 +115,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-10*time.Minute), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: false,
@@ -126,7 +126,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-10*time.Minute), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "missing-target"},
@@ -140,7 +140,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  5 * time.Minute,
 			expectedChange: false,
@@ -151,7 +151,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-3*time.Minute), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  2 * time.Minute,
 			expectedChange: false,
@@ -162,12 +162,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(1*time.Hour), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       makeCerts(t, time.Now().Add(-10*time.Minute), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  65 * time.Minute,
 			expectedChange: false,
@@ -178,12 +178,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(1*time.Hour), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -194,11 +194,11 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "missing-target"},
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -209,7 +209,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: false,
@@ -220,11 +220,11 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -235,11 +235,11 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -250,12 +250,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       makeCerts(t, time.Now().Add(-2*time.Hour), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: true,
@@ -266,7 +266,7 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       map[string][]byte{"tls.crt": {6, 6, 6}, "tls.key": {6, 6, 6}},
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: false,
@@ -277,12 +277,12 @@ func TestManageCSRSigner(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.OperatorNamespace},
 				Data:       makeCerts(t, time.Now(), 1*time.Hour),
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			target: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "csr-signer", Namespace: operatorclient.TargetNamespace},
 				Data:       map[string][]byte{"tls.crt": {6, 6, 6}, "tls.key": {6, 6, 6}},
-				Type:       corev1.SecretTypeOpaque,
+				Type:       corev1.SecretTypeTLS,
 			},
 			expectedDelay:  0,
 			expectedChange: true,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae
+# github.com/openshift/library-go v0.0.0-20200408130829-d3cb092fabfd
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
The Secret has the structure already, just fixing the type as per https://github.com/openshift/cluster-kube-controller-manager-operator/pull/390#issuecomment-610443497

Requires fixed `ApplySecret` from https://github.com/openshift/library-go/pull/768

/cc @deads2k 