### PR TITLE
Bug 1828830: add relatedobjects for immediate creation by CVO

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
@@ -13,3 +13,19 @@ status:
       version: "0.0.1-snapshot"
     - name: kube-controller-manager
       version: "0.0.1-snapshot-kubernetes"
+  relatedObjects:
+    - group: operator.openshift.io
+      name: cluster
+      resource: kubecontrollermanagers
+    - group: ""
+      name: openshift-config
+      resource: namespaces
+    - group: ""
+      name: openshift-config-managed
+      resource: namespaces
+    - group: ""
+      name: openshift-kube-controller-manager
+      resource: namespaces
+    - group: ""
+      name: openshift-kube-controller-manager-operator
+      resource: namespaces


### PR DESCRIPTION
since openshift/cluster-version-operator#318 merged we can have our relatedObjects created immediately so must-gather always works.

/cherrypick release-4.4