### PR TITLE
Bug 1825983: Sync new client cert-key on recovery

### DIFF
--- a/pkg/cmd/recoverycontroller/csrcontroller.go
+++ b/pkg/cmd/recoverycontroller/csrcontroller.go
@@ -88,6 +88,10 @@ func NewCSRController(
 	if err != nil {
 		return nil, err
 	}
+	err = operatorresourcesync.AddSyncClientCertKeySecret(c.resourceSyncController)
+	if err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -17,6 +17,13 @@ func AddSyncCSRControllerCA(resourceSyncController *resourcesynccontroller.Resou
 	)
 }
 
+func AddSyncClientCertKeySecret(resourceSyncController *resourcesynccontroller.ResourceSyncController) error {
+	return resourceSyncController.SyncSecret(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-controller-manager-client-cert-key"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-controller-manager-client-cert-key"},
+	)
+}
+
 func NewResourceSyncController(
 	operatorConfigClient v1helpers.OperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
@@ -34,10 +41,7 @@ func NewResourceSyncController(
 	if err := AddSyncCSRControllerCA(resourceSyncController); err != nil {
 		return nil, err
 	}
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-controller-manager-client-cert-key"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-controller-manager-client-cert-key"},
-	); err != nil {
+	if err := AddSyncClientCertKeySecret(resourceSyncController); err != nil {
 		return nil, err
 	}
 	if err := resourceSyncController.SyncConfigMap(


### PR DESCRIPTION
We need new client keys to be able to start KCM before operators start to fix the mess.

On recovery flow, KASO regenerate certificates routine create new KCM client certs in openshift-config-managed namespace. We need to sync them to openshift-kube-controller-manager namespace so cert syncer can sync them to disk to be live-reloaded.

/cc @deads2k @soltysh 