### PR TITLE
Bug: 1805908: Don't use upstream recycler pod

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -21,3 +21,7 @@ extendedArguments:
   service-cluster-ip-range: {{range .ServiceClusterIPRange}}
   - {{.}}{{end}}
   {{end}}
+  pv-recycler-pod-template-filepath-nfs: # bootstrap KCM doesn't need recycler templates
+  - ""
+  pv-recycler-pod-template-filepath-hostpath:
+  - ""

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -15,6 +15,10 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
+  pv-recycler-pod-template-filepath-nfs:
+  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
+  pv-recycler-pod-template-filepath-hostpath:
+  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -46,4 +50,3 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
-

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -50,6 +50,8 @@ spec:
     ports:
       - containerPort: 10257
     volumeMounts:
+    - mountPath: /etc/kubernetes/manifests
+      name: manifests-dir # Used in the KubeControllerManagerConfig to pass in recycler pod templates
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
@@ -186,6 +188,9 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
+  - hostPath:
+      path: /etc/kubernetes/manifests
+    name: manifests-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -94,6 +94,10 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
+  pv-recycler-pod-template-filepath-nfs:
+  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
+  pv-recycler-pod-template-filepath-hostpath:
+  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -125,7 +129,6 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
-
 `)
 
 func v410ConfigDefaultconfigYamlBytes() ([]byte, error) {
@@ -805,6 +808,8 @@ spec:
     ports:
       - containerPort: 10257
     volumeMounts:
+    - mountPath: /etc/kubernetes/manifests
+      name: manifests-dir # Used in the KubeControllerManagerConfig to pass in recycler pod templates
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
@@ -941,6 +946,9 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
+  - hostPath:
+      path: /etc/kubernetes/manifests
+    name: manifests-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir


### PR DESCRIPTION
If no recycler pod template is specified, the controller manager will use a default one. However, we can't rely on that one because:

1) The pod is started in the `default` namespace
2) It uses the `busybox` image

Note: the `Recycle` reclaim policy was deprecated long ago in favour of dynamic provisioning [1], but if a user happens to use this feature, we'll hit the points above.

CC @openshift/storage 

[1] https://docs.openshift.com/container-platform/4.4/storage/understanding-persistent-storage.html#reclaiming_understanding-persistent-storage