### PR TITLE
Bug 1830364: Updates Resource Graph to use default-ingress-cert CM

### DIFF
--- a/pkg/cmd/resourcegraph/resourcegraph.go
+++ b/pkg/cmd/resourcegraph/resourcegraph.go
@@ -116,7 +116,7 @@ func Resources() resourcegraph.Resources {
 		Note("Static").
 		From(installer).
 		Add(ret)
-	routerWildcardCA := resourcegraph.NewConfigMap(operatorclient.GlobalMachineSpecifiedConfigNamespace, "router-ca").
+	routerWildcardCA := resourcegraph.NewConfigMap(operatorclient.GlobalMachineSpecifiedConfigNamespace, "default-ingress-cert").
 		Note("Static").
 		From(ingressOperator).
 		Add(ret)


### PR DESCRIPTION
[This commit](https://github.com/openshift/cluster-kube-controller-manager-operator/commit/55e685148796dca181afe4330cecc60ea598d954) updated the targetconfig controller to use the "default-ingress-cert" configmap. However, the resource graph still uses the former "router-ca" configmap. This PR updates the resource graph to use "default-ingress-cert".

__Note:__ "default-ingress-cert" ConfigMap contains the self-signed CA cert and the router's server cert.
 
/cc @Miciah 