### PR TITLE
Bug 1806640: fix potential errors in Prometheus alerts

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alert-pdb.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alert-pdb.yaml
@@ -13,7 +13,7 @@ spec:
           annotations:
             message: The pod disruption budget is preventing further disruption to pods because it is at the minimum allowed level.
           expr: |
-            kube_poddisruptionbudget_status_expected_pods == on(namespace, poddisruptionbudget, service) kube_poddisruptionbudget_status_desired_healthy
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_expected_pods == kube_poddisruptionbudget_status_desired_healthy)
           for: 15m
           labels:
             severity: warning
@@ -21,7 +21,7 @@ spec:
           annotations:
             message: The pod disruption budget is below the minimum number allowed pods.
           expr: |
-            kube_poddisruptionbudget_status_expected_pods < on(namespace, poddisruptionbudget, service) kube_poddisruptionbudget_status_desired_healthy
+            max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_expected_pods < kube_poddisruptionbudget_status_desired_healthy)
           for: 15m
           labels:
             severity: critical

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -121,7 +121,7 @@ func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
 	// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
 	// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
 	// The thanos behavior is to error on partial response.
-	query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",service=\"kube-state-metrics\",severity=\"warning\"}==1", name, name)
+	query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
 	err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
 		response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
 		if err != nil {


### PR DESCRIPTION
There is no need to use the 'on' keyword to compare
kube_poddisruptionbudget_status_expected_pods and
kube_poddisruptionbudget_status_desired_healthy because both series have
the same label set. In addition when there are 2 instances of
kube-state-metrics running, it triggers evaluation errors in Prometheus.

To ensure that the expression returns one item per (namespace,
poddisruptionbudget) tuple, it is wrapped by the 'max' aggregation
operator.