### PR TITLE
Use ss instead of lsof when waiting for ports

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -19,7 +19,7 @@ spec:
     args:
     - |
       echo -n "Waiting for port :10257 and :10357 to be released."
-      while [ -n "$(lsof -ni :10257)$(lsof -ni :10357)" ]; do
+      while [ -n "$(ss -Htan '( sport = 10257 or sport = 10357 )')" ]; do
         echo -n "."
         sleep 1
       done

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -774,7 +774,7 @@ spec:
     args:
     - |
       echo -n "Waiting for port :10257 and :10357 to be released."
-      while [ -n "$(lsof -ni :10257)$(lsof -ni :10357)" ]; do
+      while [ -n "$(ss -Htan '( sport = 10257 or sport = 10357 )')" ]; do
         echo -n "."
         sleep 1
       done


### PR DESCRIPTION
This is coming from this change to kas-o https://github.com/openshift/cluster-kube-apiserver-operator/pull/864 for details why `ss` over `lsof` see this comment https://github.com/openshift/cluster-kube-apiserver-operator/pull/864#issuecomment-632322430.

/assign @sttts 