### PR TITLE
Fix port check

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -10,27 +10,16 @@ metadata:
     kube-controller-manager: "true"
     revision: "REVISION"
 spec:
-  initContainers:
-  - name: wait-for-host-ports
-    terminationMessagePolicy: FallbackToLogsOnError
-    image: ${IMAGE}
-    imagePullPolicy: IfNotPresent
-    command: ['/usr/bin/timeout', '65', '/bin/bash', '-ec'] # a bit more than 60s for TIME_WAIT, 5s extra cri-o's graceful termination period
-    args:
-    - |
-      echo -n "Waiting for port :10257 and :10357 to be released."
-      while [ -n "$(lsof -ni :10257)$(lsof -ni :10357)" ]; do
-        echo -n "."
-        sleep 1
-      done
   containers:
   - name: kube-controller-manager
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["/bin/bash", "-ec"]
+    command: ["/bin/bash", "-euxo", "pipefail", "-c"]
     args:
         - |
+          timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10257 \))" ]; do sleep 1; done'
+
           if [ -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
             echo "Copying system trust bundle"
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
@@ -47,7 +36,6 @@ spec:
               exit 1
             fi
           done
-          echo
 
           exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
             --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
@@ -66,6 +54,13 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+    startupProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 0
+      timeoutSeconds: 3
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -84,9 +79,11 @@ spec:
     image: ${CLUSTER_POLICY_CONTROLLER_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["/bin/bash", "-ec"]
+    command: ["/bin/bash", "-euxo", "pipefail", "-c"]
     args:
       - |
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10357 \))" ]; do sleep 1; done'
+
         echo -n "Waiting kube-apiserver to respond."
         tries=0
         until curl --output /dev/null --silent -k https://localhost:6443/version; do
@@ -112,6 +109,13 @@ spec:
         name: resource-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
+    startupProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10357
+        path: healthz
+      initialDelaySeconds: 0
+      timeoutSeconds: 3
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -162,12 +166,12 @@ spec:
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["cluster-kube-controller-manager-operator", "cert-recovery-controller"]
+    command: ["/bin/bash", "-euxo", "pipefail", "-c"]
     args:
-      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig
-      - --namespace=$(POD_NAMESPACE)
-      - --listen=0.0.0.0:9443
-      - -v=2
+      - |
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 9443 \))" ]; do sleep 1; done'
+
+        exec cluster-kube-controller-manager-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig --namespace=${POD_NAMESPACE} --listen=0.0.0.0:9443 -v=2
     resources:
       requests:
         memory: 50Mi


### PR DESCRIPTION
Container can be restarted while the pods stays. For that reason, we need to check the port availability in the same process as we listen, not in an init container which isn't re-run.

Adding startup probe to avoid liveness probe timeout and killing the process.

/cc @soltysh @sttts 