### PR TITLE
Bug 1835992: Raise operator e2e test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ $(call build-image,ocp-cluster-kube-controller-manager-operator,$(IMAGE_REGISTRY
 $(call add-bindata,v4.1.0,./bindata/v4.1.0/...,bindata,v411_00_assets,pkg/operator/v411_00_assets/bindata.go)
 
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
+test-e2e: GO_TEST_FLAGS :=-race -timeout=30m
 test-e2e: test-unit
 .PHONY: test-e2e
 


### PR DESCRIPTION
`TestSATokenSignerControllerSyncCerts` is seen timing out after 10 minutes in https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-kube-controller-manager-operator/405/pull-ci-openshift-cluster-kube-controller-manager-operator-master-e2e-aws-operator/1277627343967358976/artifacts/junit_operator.xml

Let's see if it's just slower infra or the test is flaky.