### PR TITLE
BUG 1853889: Add containerPort to kube-controller-manager-recovery-controller

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -169,9 +169,9 @@ spec:
     command: ["/bin/bash", "-euxo", "pipefail", "-c"]
     args:
       - |
-        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 9443 \))" ]; do sleep 1; done'
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 9445 \))" ]; do sleep 1; done'
 
-        exec cluster-kube-controller-manager-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig --namespace=${POD_NAMESPACE} --listen=0.0.0.0:9443 -v=2
+        exec cluster-kube-controller-manager-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig --namespace=${POD_NAMESPACE} --listen=0.0.0.0:9445 -v=2
     resources:
       requests:
         memory: 50Mi

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -924,9 +924,9 @@ spec:
     command: ["/bin/bash", "-euxo", "pipefail", "-c"]
     args:
       - |
-        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 9443 \))" ]; do sleep 1; done'
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 9445 \))" ]; do sleep 1; done'
 
-        exec cluster-kube-controller-manager-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig --namespace=${POD_NAMESPACE} --listen=0.0.0.0:9443 -v=2
+        exec cluster-kube-controller-manager-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig --namespace=${POD_NAMESPACE} --listen=0.0.0.0:9445 -v=2
     resources:
       requests:
         memory: 50Mi


### PR DESCRIPTION
PR[1] added logic for checking port availability in recovery-controller,
recovery-controller continer never had a containerPort and the check failed
on oVirt.
This adds a containerPort to the recovery-controller.

[1] https://github.com/openshift/cluster-kube-controller-manager-operator/pull/421
Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>