### PR TITLE
Bug 1868615: Revert "Don't use upstream recycler pod"

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -21,7 +21,3 @@ extendedArguments:
   service-cluster-ip-range: {{range .ServiceClusterIPRange}}
   - {{.}}{{end}}
   {{end}}
-  pv-recycler-pod-template-filepath-nfs: # bootstrap KCM doesn't need recycler templates
-  - ""
-  pv-recycler-pod-template-filepath-hostpath:
-  - ""

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -15,10 +15,6 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
-  pv-recycler-pod-template-filepath-nfs:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
-  pv-recycler-pod-template-filepath-hostpath:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -50,3 +46,4 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
+

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -37,8 +37,6 @@ spec:
     ports:
       - containerPort: 10257
     volumeMounts:
-    - mountPath: /etc/kubernetes/manifests
-      name: manifests-dir # Used in the KubeControllerManagerConfig to pass in recycler pod templates
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
@@ -162,9 +160,6 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
-  - hostPath:
-      path: /etc/kubernetes/manifests
-    name: manifests-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -94,10 +94,6 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
-  pv-recycler-pod-template-filepath-nfs:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
-  pv-recycler-pod-template-filepath-hostpath:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -129,6 +125,7 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
+
 `)
 
 func v410ConfigDefaultconfigYamlBytes() ([]byte, error) {
@@ -795,8 +792,6 @@ spec:
     ports:
       - containerPort: 10257
     volumeMounts:
-    - mountPath: /etc/kubernetes/manifests
-      name: manifests-dir # Used in the KubeControllerManagerConfig to pass in recycler pod templates
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
@@ -920,9 +915,6 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
-  - hostPath:
-      path: /etc/kubernetes/manifests
-    name: manifests-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir


### PR DESCRIPTION
This reverts commit 772810dce5557ea9521cc273d2d6c132a1d3d5a5 to prevent a CrashLoopBackOff if the recycler template isn't found (which can happen if this operator is upgraded before MCO).