### PR TITLE
Bug 1874532: using load balancer, there is no reason to wait on localhost

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -25,18 +25,6 @@ spec:
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
 
-          echo -n "Waiting kube-apiserver to respond."
-          tries=0
-          until curl --output /dev/null --silent -k https://localhost:6443/version; do
-            echo -n "."
-            sleep 1
-            (( tries += 1 ))
-            if [[ "${tries}" -gt 180 ]]; then
-              echo "timed out waiting for kube-apiserver to respond."
-              exit 1
-            fi
-          done
-
           exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
             --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
             --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
@@ -85,19 +73,6 @@ spec:
     args:
       - |
         timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10357 \))" ]; do sleep 1; done'
-
-        echo -n "Waiting kube-apiserver to respond."
-        tries=0
-        until curl --output /dev/null --silent -k https://localhost:6443/version; do
-          echo -n "."
-          sleep 1
-          (( tries += 1 ))
-          if [[ "${tries}" -gt 180 ]]; then
-            echo "timed out waiting for kube-apiserver to respond."
-            exit 1
-          fi
-        done
-        echo
 
         exec cluster-policy-controller start --config=/etc/kubernetes/static-pod-resources/configmaps/cluster-policy-controller-config/config.yaml
     resources:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -783,18 +783,6 @@ spec:
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
 
-          echo -n "Waiting kube-apiserver to respond."
-          tries=0
-          until curl --output /dev/null --silent -k https://localhost:6443/version; do
-            echo -n "."
-            sleep 1
-            (( tries += 1 ))
-            if [[ "${tries}" -gt 180 ]]; then
-              echo "timed out waiting for kube-apiserver to respond."
-              exit 1
-            fi
-          done
-
           exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
             --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
             --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
@@ -843,19 +831,6 @@ spec:
     args:
       - |
         timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10357 \))" ]; do sleep 1; done'
-
-        echo -n "Waiting kube-apiserver to respond."
-        tries=0
-        until curl --output /dev/null --silent -k https://localhost:6443/version; do
-          echo -n "."
-          sleep 1
-          (( tries += 1 ))
-          if [[ "${tries}" -gt 180 ]]; then
-            echo "timed out waiting for kube-apiserver to respond."
-            exit 1
-          fi
-        done
-        echo
 
         exec cluster-policy-controller start --config=/etc/kubernetes/static-pod-resources/configmaps/cluster-policy-controller-config/config.yaml
     resources:


### PR DESCRIPTION
This ensures that the kcm and kas can rollout independently and successfully.