### PR TITLE
Bug 1886022: add new apigroup to rendered clusterrole copy

### DIFF
--- a/bindata/bootkube/manifests/00_namespace-security-allocation-controller-clusterrole.yaml
+++ b/bindata/bootkube/manifests/00_namespace-security-allocation-controller-clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  - security.internal.openshift.io
   resources:
   - rangeallocations
   verbs:


### PR DESCRIPTION
the rendered peer to https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/bindata/v4.1.0/kube-controller-manager/namespace-security-allocation-controller-clusterrole.yaml#L11

