### PR TITLE
Bug 1889308: Set dnsPolicy ClusterFirstWithHostNet to match hostNetwork

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: kube-controller-manager
     image: {{ .Image }}

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -159,6 +159,7 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -919,6 +919,7 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy we should always set `dnsPolicy: ClusterFirstWithHostNet` when we have `hostNetwork: true`. 

/assign @tnozicka 