### PR TITLE
update for library-go API change (GetServiceCIDRs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20200929125329-c3027fc03b92
 	github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
-	github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7
+	github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe
 	github.com/prometheus/common v0.10.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7 h1:mO
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5 h1:E6WhVL5p3rfjtc+o+jVG/29Aclnf3XIF7akxXvadwR0=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
-github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7 h1:GpzroZdyrAqJgJw4cvgPMgrbpdhxODliIh6h3zlt3Aw=
-github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
+github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe h1:m7JIlGuocsPkfaTxhs7QhJH1K8kFaQpxmxnBTgpv0+Q=
+github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openshift/library-go/pkg/operator/configobserver"
@@ -56,13 +58,14 @@ func ObserveServiceClusterIPRanges(genericListers configobserver.Listers, record
 	}
 
 	observedConfig := map[string]interface{}{}
-	serviceCIDR, err := network.GetServiceCIDR(listers.NetworkLister, recorder)
+	serviceCIDRs, err := network.GetServiceCIDRs(listers.NetworkLister, recorder)
 	if err != nil {
 		errs = append(errs, err)
 		return previouslyObservedConfig, errs
 	}
+	serviceClusterIPRange := strings.Join(serviceCIDRs, ",")
 
-	if err := unstructured.SetNestedStringSlice(observedConfig, []string{serviceCIDR}, serviceClusterIPRangePath...); err != nil {
+	if err := unstructured.SetNestedStringSlice(observedConfig, []string{serviceClusterIPRange}, serviceClusterIPRangePath...); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/operator/configobservation/network/observe_networking_test.go
+++ b/pkg/operator/configobservation/network/observe_networking_test.go
@@ -95,7 +95,7 @@ func TestObserveClusterCIDRs(t *testing.T) {
 
 func TestObserveServiceClusterIPRanges(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := indexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Status: configv1.NetworkStatus{ServiceNetwork: []string{"serviceCIDR"}}}); err != nil {
+	if err := indexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Status: configv1.NetworkStatus{ServiceNetwork: []string{"serviceCIDRv4", "serviceCIDRv6"}}}); err != nil {
 		t.Fatal(err.Error())
 	}
 	listers := configobservation.Listers{
@@ -108,7 +108,7 @@ func TestObserveServiceClusterIPRanges(t *testing.T) {
 	expected := map[string]interface{}{
 		"extendedArguments": map[string]interface{}{
 			"service-cluster-ip-range": []interface{}{
-				"serviceCIDR",
+				"serviceCIDRv4,serviceCIDRv6",
 			},
 		},
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/network/observe_network.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/network/observe_network.go
@@ -40,24 +40,24 @@ func GetClusterCIDRs(lister configlistersv1.NetworkLister, recorder events.Recor
 	return clusterCIDRs, nil
 }
 
-// GetServiceCIDR reads the service IP range from the global network configuration resource. Emits events if CIDRs are not found.
-func GetServiceCIDR(lister configlistersv1.NetworkLister, recorder events.Recorder) (string, error) {
+// GetServiceCIDRs reads the service IP ranges from the global network configuration resource. Emits events if CIDRs are not found.
+func GetServiceCIDRs(lister configlistersv1.NetworkLister, recorder events.Recorder) ([]string, error) {
 	network, err := lister.Get("cluster")
 	if errors.IsNotFound(err) {
 		recorder.Warningf("GetServiceCIDRFailed", "Required networks.%s/cluster not found", configv1.GroupName)
-		return "", nil
+		return nil, nil
 	}
 	if err != nil {
 		recorder.Warningf("GetServiceCIDRFailed", "error getting networks.%s/cluster: %v", configv1.GroupName, err)
-		return "", err
+		return nil, err
 	}
 
 	if len(network.Status.ServiceNetwork) == 0 || len(network.Status.ServiceNetwork[0]) == 0 {
 		recorder.Warningf("GetServiceCIDRFailed", "Required status.serviceNetwork field is not set in networks.%s/cluster", configv1.GroupName)
-		return "", fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
+		return nil, fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
 	}
 
-	return network.Status.ServiceNetwork[0], nil
+	return network.Status.ServiceNetwork, nil
 }
 
 // GetExternalIPPolicy retrieves the ExternalIPPolicy for the cluster.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,7 +196,7 @@ github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7
+# github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
updates for openshift/library-go#925

This is utterly irrelevant, in that kcm's `--service-cluster-ip-range` argument currently only has any effect if (a) you're using `--allocate-node-cidrs` _and_ (b) the cluster CIDR and service CIDR overlap with each other (which I'm pretty sure openshift-install forbids). But maybe some day it will be used for something else, and we'll be ready for it! 