### PR TITLE
Revert "Set dnsPolicy ClusterFirstWithHostNet to match hostNetwork"

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: kube-controller-manager
     image: {{ .Image }}

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -159,7 +159,6 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -919,7 +919,6 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
This reverts commit 102d1e7026d046d1d9fe5a36c46dadbd1b5d5801 (#469) which is causing that our static pods have in-cluster dns server injected (see https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/pkg/kubelet/network/dns/dns.go#L348-L352), which is problematic during upgrades. I'm talking with the node team how and if this is going to be solved in kubelet. 

/assign @tnozicka