### PR TITLE
bindata: move recycler manifest

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -16,9 +16,9 @@ extendedArguments:
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
   pv-recycler-pod-template-filepath-nfs:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   pv-recycler-pod-template-filepath-hostpath:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -123,9 +123,9 @@ extendedArguments:
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
   pv-recycler-pod-template-filepath-nfs:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   pv-recycler-pod-template-filepath-hostpath:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1896226

This is the second step in resolving a bug introduced by https://github.com/openshift/machine-config-operator/pull/1687 and openshift/cluster-kube-controller-manager-operator#405

/etc/kubernetes/manifests is the kubelet's static pod manifests directory. The kubelet will try to start pods defined in this location as static pods. The recycler pod is not a static pod and the kubelet continuously fails to start it.

The solution is to move the recycler pod manifests to a different directory.

The fix is a 3-step process (as I see it):
- Change location of the recycler pod in the MCO template (https://github.com/openshift/machine-config-operator/pull/2238)
- Change KCM to use the new location (this PR)
- Delete (or empty out) the file in the old location

@runcom @sttts @rphillips @haircommander 