### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_25_kube-controller-manager-operator_01_operator.cr.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_01_operator.cr.yaml
@@ -6,5 +6,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: kube-controller-manager-operator
   name: metrics

--- a/manifests/0000_25_kube-controller-manager-operator_03_configmap.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_03_configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/0000_25_kube-controller-manager-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_04_clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_25_kube-controller-manager-operator_05_serviceaccount.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_05_serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_90_kube-controller-manager-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_01_prometheusrole.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_kube-controller-manager-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_02_prometheusrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -26,6 +27,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -45,6 +47,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:
     - name: cluster-version


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.