### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"

--- a/manifests/0000_25_kube-controller-manager-operator_01_operator.cr.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_01_operator.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
   labels:
     app: kube-controller-manager-operator

--- a/manifests/0000_25_kube-controller-manager-operator_03_configmap.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_03_configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/0000_25_kube-controller-manager-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_04_clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_25_kube-controller-manager-operator_05_serviceaccount.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_05_serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_90_kube-controller-manager-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_01_prometheusrole.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_kube-controller-manager-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_02_prometheusrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -26,6 +27,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -45,6 +47,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
     - name: cluster-version


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-kube-controller-manager-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.