### PR TITLE
Bug 1912888: Add recycler pod template as a ConfigMap

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -21,3 +21,7 @@ extendedArguments:
   service-cluster-ip-range: {{range .ServiceClusterIPRange}}
   - {{.}}{{end}}
   {{end}}
+  pv-recycler-pod-template-filepath-nfs: # bootstrap KCM doesn't need recycler templates
+  - ""
+  pv-recycler-pod-template-filepath-hostpath:
+  - ""

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -21,7 +21,3 @@ extendedArguments:
   service-cluster-ip-range: {{range .ServiceClusterIPRange}}
   - {{.}}{{end}}
   {{end}}
-  pv-recycler-pod-template-filepath-nfs: # bootstrap KCM doesn't need recycler templates
-  - ""
-  pv-recycler-pod-template-filepath-hostpath:
-  - ""

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -11,10 +11,6 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
-  pv-recycler-pod-template-filepath-nfs:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
-  pv-recycler-pod-template-filepath-hostpath:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -46,3 +42,4 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
+

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -11,6 +11,10 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
+  pv-recycler-pod-template-filepath-nfs: # owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml"
+  pv-recycler-pod-template-filepath-hostpath: # owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml"
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -42,4 +46,3 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
-

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -38,8 +38,6 @@ spec:
     ports:
       - containerPort: 10257
     volumeMounts:
-    - mountPath: /etc/kubernetes/manifests
-      name: manifests-dir # Used in the KubeControllerManagerConfig to pass in recycler pod templates
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
@@ -163,9 +161,6 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
-  - hostPath:
-      path: /etc/kubernetes/manifests
-    name: manifests-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir

--- a/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: recycler-config
+data:
+  recycler-pod.yaml: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: recycler-pod
+      namespace: openshift-infra
+    spec:
+      activeDeadlineSeconds: 60
+      restartPolicy: Never
+      serviceAccountName: pv-recycler-controller
+      containers:
+        - name: recycler-container
+          image: "${TOOLS_IMAGE}"
+          command:
+          - "/bin/bash"
+          args:
+          - "-c"
+          - "test -e /scrub && rm -rf /scrub/..?* /scrub/.[!.]* /scrub/*  && test -z \"$(ls -A /scrub)\" || exit 1"
+          volumeMounts:
+            - mountPath: /scrub
+              name: vol
+          securityContext:
+            runAsUser: 0
+      volumes:
+        - name: vol

--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -49,6 +49,8 @@ spec:
           value: docker.io/openshift/origin-cluster-kube-controller-manager-operator:v4.0
         - name: CLUSTER_POLICY_CONTROLLER_IMAGE
           value: quay.io/openshift/origin-cluster-policy-controller:v4.3
+        - name: TOOLS_IMAGE
+          value: quay.io/openshift/origin-tools:latest
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERAND_IMAGE_VERSION

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,3 +14,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-policy-controller:v4.3
+  - name: tools # owned by storage team/fbertina@redhat.com
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-tools:latest

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -104,6 +104,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		os.Getenv("IMAGE"),
 		os.Getenv("OPERATOR_IMAGE"),
 		os.Getenv("CLUSTER_POLICY_CONTROLLER_IMAGE"),
+		os.Getenv("TOOLS_IMAGE"),
 		kubeInformersForNamespaces,
 		operatorClient,
 		kubeClient,
@@ -218,6 +219,7 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "kube-controller-cert-syncer-kubeconfig"},
 	{Name: "serviceaccount-ca"},
 	{Name: "service-ca"},
+	{Name: "recycler-config"},
 }
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -118,10 +118,6 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
-  pv-recycler-pod-template-filepath-nfs:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
-  pv-recycler-pod-template-filepath-hostpath:
-  - "/etc/kubernetes/manifests/recycler-pod.yaml" # created by machine-config-operator, owned by storage team/fbertina@redhat.com
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -153,6 +149,7 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
+
 `)
 
 func v410ConfigDefaultconfigYamlBytes() ([]byte, error) {
@@ -794,8 +791,6 @@ spec:
     ports:
       - containerPort: 10257
     volumeMounts:
-    - mountPath: /etc/kubernetes/manifests
-      name: manifests-dir # Used in the KubeControllerManagerConfig to pass in recycler pod templates
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
@@ -919,9 +914,6 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
-  - hostPath:
-      path: /etc/kubernetes/manifests
-    name: manifests-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-REVISION
     name: resource-dir

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -21,6 +21,7 @@
 // bindata/v4.1.0/kube-controller-manager/ns.yaml
 // bindata/v4.1.0/kube-controller-manager/pod-cm.yaml
 // bindata/v4.1.0/kube-controller-manager/pod.yaml
+// bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
 // bindata/v4.1.0/kube-controller-manager/sa.yaml
 // bindata/v4.1.0/kube-controller-manager/svc.yaml
 // bindata/v4.1.0/kube-controller-manager/trusted-ca-cm.yaml
@@ -118,6 +119,10 @@ extendedArguments:
   - "true"
   flex-volume-plugin-dir:
   - "/etc/kubernetes/kubelet-plugins/volume/exec" # created by machine-config-operator, owned by storage team/hekumar@redhat.com
+  pv-recycler-pod-template-filepath-nfs: # owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml"
+  pv-recycler-pod-template-filepath-hostpath: # owned by storage team/fbertina@redhat.com
+  - "/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml"
   leader-elect:
   - "true"
   leader-elect-retry-period:
@@ -149,7 +154,6 @@ extendedArguments:
   - "150" # this is a historical values
   kube-api-burst:
   - "300" # this is a historical values
-
 `)
 
 func v410ConfigDefaultconfigYamlBytes() ([]byte, error) {
@@ -937,6 +941,54 @@ func v410KubeControllerManagerPodYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v410KubeControllerManagerRecyclerCmYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-controller-manager
+  name: recycler-config
+data:
+  recycler-pod.yaml: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: recycler-pod
+      namespace: openshift-infra
+    spec:
+      activeDeadlineSeconds: 60
+      restartPolicy: Never
+      serviceAccountName: pv-recycler-controller
+      containers:
+        - name: recycler-container
+          image: "${TOOLS_IMAGE}"
+          command:
+          - "/bin/bash"
+          args:
+          - "-c"
+          - "test -e /scrub && rm -rf /scrub/..?* /scrub/.[!.]* /scrub/*  && test -z \"$(ls -A /scrub)\" || exit 1"
+          volumeMounts:
+            - mountPath: /scrub
+              name: vol
+          securityContext:
+            runAsUser: 0
+      volumes:
+        - name: vol
+`)
+
+func v410KubeControllerManagerRecyclerCmYamlBytes() ([]byte, error) {
+	return _v410KubeControllerManagerRecyclerCmYaml, nil
+}
+
+func v410KubeControllerManagerRecyclerCmYaml() (*asset, error) {
+	bytes, err := v410KubeControllerManagerRecyclerCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-controller-manager/recycler-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v410KubeControllerManagerSaYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -1089,6 +1141,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v4.1.0/kube-controller-manager/ns.yaml":                                                              v410KubeControllerManagerNsYaml,
 	"v4.1.0/kube-controller-manager/pod-cm.yaml":                                                          v410KubeControllerManagerPodCmYaml,
 	"v4.1.0/kube-controller-manager/pod.yaml":                                                             v410KubeControllerManagerPodYaml,
+	"v4.1.0/kube-controller-manager/recycler-cm.yaml":                                                     v410KubeControllerManagerRecyclerCmYaml,
 	"v4.1.0/kube-controller-manager/sa.yaml":                                                              v410KubeControllerManagerSaYaml,
 	"v4.1.0/kube-controller-manager/svc.yaml":                                                             v410KubeControllerManagerSvcYaml,
 	"v4.1.0/kube-controller-manager/trusted-ca-cm.yaml":                                                   v410KubeControllerManagerTrustedCaCmYaml,
@@ -1162,6 +1215,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"ns.yaml":            {v410KubeControllerManagerNsYaml, map[string]*bintree{}},
 			"pod-cm.yaml":        {v410KubeControllerManagerPodCmYaml, map[string]*bintree{}},
 			"pod.yaml":           {v410KubeControllerManagerPodYaml, map[string]*bintree{}},
+			"recycler-cm.yaml":   {v410KubeControllerManagerRecyclerCmYaml, map[string]*bintree{}},
 			"sa.yaml":            {v410KubeControllerManagerSaYaml, map[string]*bintree{}},
 			"svc.yaml":           {v410KubeControllerManagerSvcYaml, map[string]*bintree{}},
 			"trusted-ca-cm.yaml": {v410KubeControllerManagerTrustedCaCmYaml, map[string]*bintree{}},


### PR DESCRIPTION
* Reverts https://github.com/openshift/cluster-kube-controller-manager-operator/commit/a45783fc03f3bdd5e0192db53ef061ba5b00ed22. This relied on a template file created by MCO, which updates after KCMO
* Creates a ConfigMap with the recycler template in it
* Projects the ConfigMap as a file to be used by the KCM pod
* Passes the projected template file to KCM as an extended arg