### PR TITLE
Bug 1915500: support custom CA bundle for AWS C2S

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -25,6 +25,11 @@ spec:
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
 
+          if [ -f /etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem ]; then
+            echo "Setting custom CA bundle for cloud provider"
+            export AWS_CA_BUNDLE=/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem
+          fi
+
           exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
             --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
             --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -782,6 +782,11 @@ spec:
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
 
+          if [ -f /etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem ]; then
+            echo "Setting custom CA bundle for cloud provider"
+            export AWS_CA_BUNDLE=/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem
+          fi
+
           exec hyperkube kube-controller-manager --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml \
             --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
             --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \


### PR DESCRIPTION
Communication with the AWS API in the C2S Secret region requires a custom CA bundle. This bundle is stored in the "ca-bundle.pem" entry in the cloud-config. The AWS_CA_BUNDLE environment variable informs the AWS SDK to use a custom CA bundle and to specify the location of the bundle.