### PR TITLE
Bug 1920159: Adjust CPU request for controller manager more precisely

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -39,7 +39,7 @@ spec:
     resources:
       requests:
         memory: 200Mi
-        cpu: 80m
+        cpu: 60m
     ports:
       - containerPort: 10257
     volumeMounts:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -796,7 +796,7 @@ spec:
     resources:
       requests:
         memory: 200Mi
-        cpu: 80m
+        cpu: 60m
     ports:
       - containerPort: 10257
     volumeMounts:


### PR DESCRIPTION
The actual use of the KCM in large production environments is
slightly lower than the request, and is fairly constant. In order
to ensure more headroom is available on small node sizes, tweak
downwards closer to the observed 40m real usage while still leaving
some headroom.

/hold

For testing with the other related changes