### PR TITLE
bug 1844989: Allow to set --tls-cipher-suites and --tls-min-version of KCM instances through observed config

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -6,6 +6,7 @@ import (
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
+	libgoapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/configobserver/proxy"
@@ -63,6 +64,7 @@ func NewConfigObserver(
 				InfrastructureLister_: configinformers.Config().V1().Infrastructures().Lister(),
 				NetworkLister:         configinformers.Config().V1().Networks().Lister(),
 				ProxyLister_:          configinformers.Config().V1().Proxies().Lister(),
+				APIServerLister_:      configinformers.Config().V1().APIServers().Lister(),
 
 				ResourceSync:     resourceSyncer,
 				ConfigMapLister_: kubeInformersForNamespaces.ConfigMapLister(),
@@ -93,6 +95,7 @@ func NewConfigObserver(
 			proxy.NewProxyObserveFunc([]string{"targetconfigcontroller", "proxy"}),
 			serviceca.ObserveServiceCA,
 			clustername.ObserveInfraID,
+			libgoapiserver.ObserveTLSSecurityProfile,
 		),
 	}
 

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -17,6 +17,7 @@ type Listers struct {
 	NetworkLister         configlistersv1.NetworkLister
 	ProxyLister_          configlistersv1.ProxyLister
 	ConfigMapLister_      corev1listers.ConfigMapLister
+	APIServerLister_      configlistersv1.APIServerLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced []cache.InformerSynced
@@ -44,4 +45,8 @@ func (l Listers) PreRunHasSynced() []cache.InformerSynced {
 
 func (l Listers) ConfigMapLister() corev1listers.ConfigMapLister {
 	return l.ConfigMapLister_
+}
+
+func (l Listers) APIServerLister() configlistersv1.APIServerLister {
+	return l.APIServerLister_
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/listers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/listers.go
@@ -1,0 +1,9 @@
+package apiserver
+
+import (
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+type APIServerLister interface {
+	APIServerLister() configlistersv1.APIServerLister
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_audit.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_audit.go
@@ -1,0 +1,88 @@
+package apiserver
+
+import (
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// AuditPolicyPathGetterFunc allows the observer to be agnostic of the source of audit profile(s).
+// The function returns the path to the audit policy file (associated with the
+// given profile) in the static manifest folder.
+type AuditPolicyPathGetterFunc func(profile string) (string, error)
+
+// NewAuditObserver returns an ObserveConfigFunc that observes the audit field of the APIServer resource
+// and sets the apiServerArguments:audit-policy-file field for the apiserver appropriately.
+func NewAuditObserver(pathGetter AuditPolicyPathGetterFunc) configobserver.ObserveConfigFunc {
+	var (
+		apiServerArgumentsAuditPath = []string{"apiServerArguments", "audit-policy-file"}
+	)
+
+	return func(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observed map[string]interface{}, _ []error) {
+		defer func() {
+			observed = configobserver.Pruned(observed, apiServerArgumentsAuditPath)
+		}()
+
+		errs := []error{}
+
+		// if the function encounters an error it returns existing/current config, which means that
+		// some other entity (default config in bindata ) must ensure to default the configuration.
+		// otherwise, the apiserver won't have a path to audit policy file and it will fail to start.
+		listers := genericListers.(APIServerLister)
+		apiServer, err := listers.APIServerLister().Get("cluster")
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+
+				return existingConfig, errs
+			}
+
+			return existingConfig, append(errs, err)
+		}
+
+		desiredProfile := string(apiServer.Spec.Audit.Profile)
+		if len(desiredProfile) == 0 {
+			// The specified Profile is empty, so let the defaulting layer choose a default for us.
+			return map[string]interface{}{}, errs
+		}
+
+		desiredAuditPolicyPath, err := pathGetter(desiredProfile)
+		if err != nil {
+			return existingConfig, append(errs, fmt.Errorf("audit profile is not valid name=%s", desiredProfile))
+		}
+
+		currentAuditPolicyPath, err := getCurrentPolicyPath(existingConfig, apiServerArgumentsAuditPath...)
+		if err != nil {
+			return existingConfig, append(errs, fmt.Errorf("audit profile is not valid name=%s", desiredProfile))
+		}
+		if desiredAuditPolicyPath == currentAuditPolicyPath {
+			return existingConfig, errs
+		}
+
+		// we have a change of audit policy here!
+		observedConfig := map[string]interface{}{}
+		if err := unstructured.SetNestedStringSlice(observedConfig, []string{desiredAuditPolicyPath}, apiServerArgumentsAuditPath...); err != nil {
+			return existingConfig, append(errs, fmt.Errorf("failed to set desired audit profile in observed config name=%s", desiredProfile))
+		}
+
+		recorder.Eventf("ObserveAPIServerArgumentsAudit", "audit policy has been set to profile=%s", desiredProfile)
+		return observedConfig, errs
+	}
+}
+
+func getCurrentPolicyPath(existing map[string]interface{}, fields ...string) (string, error) {
+	current, _, err := unstructured.NestedStringSlice(existing, fields...)
+	if err != nil {
+		return "", err
+	}
+	if len(current) == 0 {
+		return "", nil
+	}
+
+	return current[0], nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_cors.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_cors.go
@@ -1,0 +1,75 @@
+package apiserver
+
+import (
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var clusterDefaultCORSAllowedOrigins = []string{
+	`//127\.0\.0\.1(:|$)`,
+	`//localhost(:|$)`,
+}
+
+// ObserveAdditionalCORSAllowedOrigins observes the additionalCORSAllowedOrigins field
+// of the APIServer resource and sets the corsAllowedOrigins field of observedConfig
+func ObserveAdditionalCORSAllowedOrigins(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerObserveAdditionalCORSAllowedOrigins(genericListers, recorder, existingConfig, []string{"corsAllowedOrigins"})
+}
+
+// ObserveAdditionalCORSAllowedOriginsToArguments observes the additionalCORSAllowedOrigins field
+// of the APIServer resource and sets the cors-allowed-origins field in observedConfig.apiServerArguments
+func ObserveAdditionalCORSAllowedOriginsToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerObserveAdditionalCORSAllowedOrigins(genericListers, recorder, existingConfig, []string{"apiServerArguments", "cors-allowed-origins"})
+}
+
+func innerObserveAdditionalCORSAllowedOrigins(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, corsAllowedOriginsPath []string) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, corsAllowedOriginsPath)
+	}()
+
+	lister := genericListers.(APIServerLister)
+	errs := []error{}
+	defaultConfig := map[string]interface{}{}
+	if err := unstructured.SetNestedStringSlice(defaultConfig, clusterDefaultCORSAllowedOrigins, corsAllowedOriginsPath...); err != nil {
+		// this should not happen
+		return existingConfig, append(errs, err)
+	}
+
+	// grab the current CORS origins to later check whether they were updated
+	currentCORSAllowedOrigins, _, err := unstructured.NestedStringSlice(existingConfig, corsAllowedOriginsPath...)
+	if err != nil {
+		errs = append(errs, err)
+		// keep going on read error from existing config
+	}
+	currentCORSSet := sets.NewString(currentCORSAllowedOrigins...)
+	currentCORSSet.Insert(clusterDefaultCORSAllowedOrigins...)
+
+	observedConfig := map[string]interface{}{}
+	apiServer, err := lister.APIServerLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+		return defaultConfig, errs
+	}
+	if err != nil {
+		// return existingConfig here in case err is just a transient error so
+		// that we don't rewrite the config that was observed previously
+		return existingConfig, append(errs, err)
+	}
+
+	newCORSSet := sets.NewString(clusterDefaultCORSAllowedOrigins...)
+	newCORSSet.Insert(apiServer.Spec.AdditionalCORSAllowedOrigins...)
+	if err := unstructured.SetNestedStringSlice(observedConfig, newCORSSet.List(), corsAllowedOriginsPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if !currentCORSSet.Equal(newCORSSet) {
+		recorder.Eventf("ObserveAdditionalCORSAllowedOrigins", "corsAllowedOrigins changed to %q", newCORSSet.List())
+	}
+
+	return observedConfig, errs
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -1,0 +1,103 @@
+package apiserver
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ObserveTLSSecurityProfile observes APIServer.Spec.TLSSecurityProfile field and sets
+// the ServingInfo.MinTLSVersion, ServingInfo.CipherSuites fields of observed config
+func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"servingInfo", "minTLSVersion"}, []string{"servingInfo", "cipherSuites"})
+}
+
+// ObserveTLSSecurityProfileToArguments observes APIServer.Spec.TLSSecurityProfile field and sets
+// the tls-min-version and tls-cipher-suites fileds of observedConfig.apiServerArguments
+func ObserveTLSSecurityProfileToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"apiServerArguments", "tls-min-version"}, []string{"apiServerArguments", "tls-cipher-suites"})
+}
+
+func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath []string) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, minTLSVersionPath, cipherSuitesPath)
+	}()
+
+	listers := genericListers.(APIServerLister)
+	errs := []error{}
+
+	currentMinTLSVersion, _, versionErr := unstructured.NestedString(existingConfig, minTLSVersionPath...)
+	if versionErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.minTLSVersion: %v", versionErr))
+		// keep going on read error from existing config
+	}
+
+	currentCipherSuites, _, suitesErr := unstructured.NestedStringSlice(existingConfig, cipherSuitesPath...)
+	if suitesErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.cipherSuites: %v", suitesErr))
+		// keep going on read error from existing config
+	}
+
+	apiServer, err := listers.APIServerLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+		apiServer = &configv1.APIServer{}
+	} else if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
+	if err = unstructured.SetNestedField(observedConfig, observedMinTLSVersion, minTLSVersionPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+	if err = unstructured.SetNestedStringSlice(observedConfig, observedCipherSuites, cipherSuitesPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if observedMinTLSVersion != currentMinTLSVersion {
+		recorder.Eventf("ObserveTLSSecurityProfile", "minTLSVersion changed to %s", observedMinTLSVersion)
+	}
+	if !reflect.DeepEqual(observedCipherSuites, currentCipherSuites) {
+		recorder.Eventf("ObserveTLSSecurityProfile", "cipherSuites changed to %q", observedCipherSuites)
+	}
+
+	return observedConfig, errs
+}
+
+// Extracts the minimum TLS version and cipher suites from TLSSecurityProfile object,
+// Converts the ciphers to IANA names as supported by Kube ServingInfo config.
+// If profile is nil, returns config defined by the Intermediate TLS Profile
+func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string) {
+	var profileType configv1.TLSProfileType
+	if profile == nil {
+		profileType = configv1.TLSProfileIntermediateType
+	} else {
+		profileType = profile.Type
+	}
+
+	var profileSpec *configv1.TLSProfileSpec
+	if profileType == configv1.TLSProfileCustomType {
+		if profile.Custom != nil {
+			profileSpec = &profile.Custom.TLSProfileSpec
+		}
+	} else {
+		profileSpec = configv1.TLSProfiles[profileType]
+	}
+
+	// nothing found / custom type set but no actual custom spec
+	if profileSpec == nil {
+		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	// need to remap all Ciphers to their respective IANA names used by Go
+	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,6 +215,7 @@ github.com/openshift/library-go/pkg/network
 github.com/openshift/library-go/pkg/operator/certrotation
 github.com/openshift/library-go/pkg/operator/condition
 github.com/openshift/library-go/pkg/operator/configobserver
+github.com/openshift/library-go/pkg/operator/configobserver/apiserver
 github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider
 github.com/openshift/library-go/pkg/operator/configobserver/featuregates
 github.com/openshift/library-go/pkg/operator/configobserver/network


### PR DESCRIPTION
By allowing to set the ciphers, KCM does not have to use the default ciphers some of which may contain security vulnerabilities.

Blocked by https://github.com/openshift/cluster-policy-controller/pull/56