### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -8,6 +8,7 @@ metadata:
     openshift.io/component: "controller-manager"
   annotations:
     openshift.io/run-level: "0"
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/bindata/bootkube/manifests/00_openshift-kube-controller-manager-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-controller-manager-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-controller-manager
   labels:
     openshift.io/run-level: "0"

--- a/bindata/bootkube/manifests/00_openshift-kube-controller-manager-operator-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-controller-manager-operator-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/bindata/v4.1.0/kube-controller-manager/ns.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-controller-manager
   labels:
     openshift.io/run-level: "0"

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-controller-manager
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: kube-controller-manager
     kube-controller-manager: "true"

--- a/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
@@ -10,6 +10,8 @@ data:
     metadata:
       name: recycler-pod
       namespace: openshift-infra
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       activeDeadlineSeconds: 60
       restartPolicy: Never

--- a/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: kube-controller-manager-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-controller-manager-operator
     spec:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -708,6 +708,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-controller-manager
   labels:
     openshift.io/run-level: "0"
@@ -762,6 +763,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-controller-manager
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: kube-controller-manager
     kube-controller-manager: "true"
@@ -958,6 +960,8 @@ data:
     metadata:
       name: recycler-pod
       namespace: openshift-infra
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       activeDeadlineSeconds: 60
       restartPolicy: Never


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.