### PR TITLE
Bug 1949418: bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openshift/api v0.0.0-20210409143810-a99ffa1cac67
 	github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 	github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
 	github.com/prometheus/common v0.10.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359 h1:eh
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pPSaTa1i+4Xp6FfVzZRFRETsnPfwz6VBXM=
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc h1:tywho0nChchtAD4E2YmlX9MWQ3CBoWT49GrTHfM2+ss=
+github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
@@ -76,7 +76,7 @@ func waitForNamedCacheSync(controllerName string, stopCh <-chan struct{}, cacheS
 
 func (c *baseController) Run(ctx context.Context, workers int) {
 	// HandleCrash recovers panics
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrash(c.degradedPanicHandler)
 
 	// give caches 10 minutes to sync
 	cacheSyncCtx, cacheSyncCancel := context.WithTimeout(ctx, c.cacheSyncTimeout)
@@ -183,40 +183,53 @@ func (c *baseController) runPeriodicalResync(ctx context.Context, interval time.
 // The worker is asked to terminate when the passed context is cancelled and is given terminationGraceDuration time
 // to complete its shutdown.
 func (c *baseController) runWorker(queueCtx context.Context) {
-	var workerWaitGroup sync.WaitGroup
-	workerWaitGroup.Add(1)
-	go func() {
-		defer utilruntime.HandleCrash()
-		defer workerWaitGroup.Done()
-		for {
-			select {
-			case <-queueCtx.Done():
-				return
-			default:
-				c.processNextWorkItem(queueCtx)
+	wait.UntilWithContext(
+		queueCtx,
+		func(queueCtx context.Context) {
+			defer utilruntime.HandleCrash(c.degradedPanicHandler)
+			for {
+				select {
+				case <-queueCtx.Done():
+					return
+				default:
+					c.processNextWorkItem(queueCtx)
+				}
 			}
-		}
-	}()
-	workerWaitGroup.Wait()
+		},
+		1*time.Second)
 }
 
 // reconcile wraps the sync() call and if operator client is set, it handle the degraded condition if sync() returns an error.
 func (c *baseController) reconcile(ctx context.Context, syncCtx SyncContext) error {
 	err := c.sync(ctx, syncCtx)
+	return c.reportDegraded(ctx, err)
+}
+
+// degradedPanicHandler will go degraded on failures, then we should catch potential panics and covert them into bad status.
+func (c *baseController) degradedPanicHandler(panicVal interface{}) {
 	if c.syncDegradedClient == nil {
-		return err
+		// if we don't have a client for reporting degraded condition, then let the existing panic handler do the work
+		return
 	}
-	if err != nil {
+	_ = c.reportDegraded(context.TODO(), fmt.Errorf("panic caught:\n%v", panicVal))
+}
+
+// reportDegraded updates status with an indication of degraded-ness
+func (c *baseController) reportDegraded(ctx context.Context, reportedError error) error {
+	if c.syncDegradedClient == nil {
+		return reportedError
+	}
+	if reportedError != nil {
 		_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    c.name + "Degraded",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "SyncError",
-			Message: err.Error(),
+			Message: reportedError.Error(),
 		}))
 		if updateErr != nil {
 			klog.Warningf("Updating status of %q failed: %v", c.Name(), updateErr)
 		}
-		return err
+		return reportedError
 	}
 	_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient,
 		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -2,22 +2,25 @@ package resourceapply
 
 import (
 	"fmt"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"github.com/openshift/api"
-	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/api"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 var (
@@ -47,6 +50,7 @@ type ClientHolder struct {
 	kubeClient          kubernetes.Interface
 	apiExtensionsClient apiextensionsclient.Interface
 	kubeInformers       v1helpers.KubeInformersForNamespaces
+	dynamicClient       dynamic.Interface
 }
 
 func NewClientHolder() *ClientHolder {
@@ -72,6 +76,11 @@ func (c *ClientHolder) WithAPIExtensionsClient(client apiextensionsclient.Interf
 	return c
 }
 
+func (c *ClientHolder) WithDynamicClient(client dynamic.Interface) *ClientHolder {
+	c.dynamicClient = client
+	return c
+}
+
 // ApplyDirectly applies the given manifest files to API server.
 func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests AssetFunc, files ...string) []ApplyResult {
 	ret := []ApplyResult{}
@@ -84,7 +93,7 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 			ret = append(ret, result)
 			continue
 		}
-		requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
+		requiredObj, err := decode(objBytes)
 		if err != nil {
 			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)
 			ret = append(ret, result)
@@ -97,75 +106,95 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 		case *corev1.Namespace:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyNamespace(clients.kubeClient.CoreV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyNamespace(clients.kubeClient.CoreV1(), recorder, t)
 		case *corev1.Service:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyService(clients.kubeClient.CoreV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyService(clients.kubeClient.CoreV1(), recorder, t)
 		case *corev1.Pod:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyPod(clients.kubeClient.CoreV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyPod(clients.kubeClient.CoreV1(), recorder, t)
 		case *corev1.ServiceAccount:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyServiceAccount(clients.kubeClient.CoreV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyServiceAccount(clients.kubeClient.CoreV1(), recorder, t)
 		case *corev1.ConfigMap:
 			client := clients.configMapsGetter()
 			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyConfigMap(client, recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyConfigMap(client, recorder, t)
 		case *corev1.Secret:
 			client := clients.secretsGetter()
 			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplySecret(client, recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplySecret(client, recorder, t)
 		case *rbacv1.ClusterRole:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyClusterRole(clients.kubeClient.RbacV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyClusterRole(clients.kubeClient.RbacV1(), recorder, t)
 		case *rbacv1.ClusterRoleBinding:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyClusterRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyClusterRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
 		case *rbacv1.Role:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyRole(clients.kubeClient.RbacV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyRole(clients.kubeClient.RbacV1(), recorder, t)
 		case *rbacv1.RoleBinding:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
 		case *apiextensionsv1beta1.CustomResourceDefinition:
 			if clients.apiExtensionsClient == nil {
 				result.Error = fmt.Errorf("missing apiExtensionsClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1Beta1(clients.apiExtensionsClient.ApiextensionsV1beta1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1Beta1(clients.apiExtensionsClient.ApiextensionsV1beta1(), recorder, t)
 		case *apiextensionsv1.CustomResourceDefinition:
 			if clients.apiExtensionsClient == nil {
 				result.Error = fmt.Errorf("missing apiExtensionsClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1(clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1(clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
 		case *storagev1.StorageClass:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyStorageClass(clients.kubeClient.StorageV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyStorageClass(clients.kubeClient.StorageV1(), recorder, t)
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyCSIDriver(clients.kubeClient.StorageV1(), recorder, t)
 			}
-			result.Result, result.Changed, result.Error = ApplyCSIDriver(clients.kubeClient.StorageV1(), recorder, t)
+		case *unstructured.Unstructured:
+			if clients.dynamicClient == nil {
+				result.Error = fmt.Errorf("missing dynamicClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyKnownUnstructured(clients.dynamicClient, recorder, t)
+			}
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
 		}
@@ -194,4 +223,20 @@ func (c *ClientHolder) secretsGetter() corev1client.SecretsGetter {
 		return c.kubeClient.CoreV1()
 	}
 	return v1helpers.CachedSecretGetter(c.kubeClient.CoreV1(), c.kubeInformers)
+}
+
+func decode(objBytes []byte) (runtime.Object, error) {
+	// Try to get a typed object first
+	typedObj, _, decodeErr := genericCodec.Decode(objBytes, nil, nil)
+	if decodeErr == nil {
+		return typedObj, nil
+	}
+
+	// Try unstructured, hoping to recover from "no kind XXX is registered for version YYY"
+	unstructuredObj, _, err := scheme.Codecs.UniversalDecoder().Decode(objBytes, nil, &unstructured.Unstructured{})
+	if err != nil {
+		// Return the original error
+		return nil, decodeErr
+	}
+	return unstructuredObj, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
@@ -2,9 +2,7 @@ package resourceapply
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
 	"k8s.io/klog/v2"
 
@@ -12,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
@@ -48,58 +45,44 @@ func ensureServiceMonitorSpec(required, existing *unstructured.Unstructured) (*u
 }
 
 // ApplyServiceMonitor applies the Prometheus service monitor.
-func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, serviceMonitorBytes []byte) (bool, error) {
-	monitorJSON, err := yaml.YAMLToJSON(serviceMonitorBytes)
-	if err != nil {
-		return false, err
-	}
-
-	monitorObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, monitorJSON)
-	if err != nil {
-		return false, err
-	}
-
-	required, ok := monitorObj.(*unstructured.Unstructured)
-	if !ok {
-		return false, fmt.Errorf("unexpected object in %t", monitorObj)
-	}
-
+func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
 	namespace := required.GetNamespace()
 
 	existing, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Get(context.TODO(), required.GetName(), metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		_, createErr := client.Resource(serviceMonitorGVR).Namespace(namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		newObj, createErr := client.Resource(serviceMonitorGVR).Namespace(namespace).Create(context.TODO(), required, metav1.CreateOptions{})
 		if createErr != nil {
 			recorder.Warningf("ServiceMonitorCreateFailed", "Failed to create ServiceMonitor.monitoring.coreos.com/v1: %v", createErr)
-			return true, createErr
+			return nil, true, createErr
 		}
 		recorder.Eventf("ServiceMonitorCreated", "Created ServiceMonitor.monitoring.coreos.com/v1 because it was missing")
-		return true, nil
+		return newObj, true, nil
 	}
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
 	existingCopy := existing.DeepCopy()
 
 	updated, endpointsModified, err := ensureServiceMonitorSpec(required, existingCopy)
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
 	if !endpointsModified {
-		return false, nil
+		return nil, false, nil
 	}
 
 	if klog.V(4).Enabled() {
 		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, existingCopy))
 	}
 
-	if _, err = client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), updated, metav1.UpdateOptions{}); err != nil {
+	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), updated, metav1.UpdateOptions{})
+	if err != nil {
 		recorder.Warningf("ServiceMonitorUpdateFailed", "Failed to update ServiceMonitor.monitoring.coreos.com/v1: %v", err)
-		return true, err
+		return nil, true, err
 	}
 
 	recorder.Eventf("ServiceMonitorUpdated", "Updated ServiceMonitor.monitoring.coreos.com/v1 because it changed")
-	return true, err
+	return newObj, true, err
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
@@ -1,0 +1,21 @@
+package resourceapply
+
+import (
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// ApplyKnownUnstructured applies few selected Unstructured types, where it semantic knowledge
+// to merge existing & required objects intelligently. Feel free to add more.
+func ApplyKnownUnstructured(client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	serviceMonitorGK := schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}
+	if obj.GetObjectKind().GroupVersionKind().GroupKind() == serviceMonitorGK {
+		return ApplyServiceMonitor(client, recorder, obj)
+	}
+
+	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/unstructured.go
@@ -6,6 +6,10 @@ import (
 )
 
 func ReadCredentialRequestsOrDie(objBytes []byte) *unstructured.Unstructured {
+	return ReadUnstructuredOrDie(objBytes)
+}
+
+func ReadUnstructuredOrDie(objBytes []byte) *unstructured.Unstructured {
 	udi, _, err := scheme.Codecs.UniversalDecoder().Decode(objBytes, nil, &unstructured.Unstructured{})
 	if err != nil {
 		panic(err)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -127,7 +127,12 @@ func (c *StaticPodStateController) sync(ctx context.Context, syncCtx factory.Syn
 
 	switch {
 	case len(images) == 0:
-		syncCtx.Recorder().Warningf("MissingVersion", "no image found for operand pod")
+		// if NodeStatuses is still empty, we are most probably in bootstrapping phase and this controller races with the
+		// installer controller. Hence, ignore that case. It will settle.
+
+		if len(originalOperatorStatus.NodeStatuses) > 0 {
+			syncCtx.Recorder().Warningf("MissingVersion", "no image found for operand pod")
+		}
 
 	case len(images) > 1:
 		syncCtx.Recorder().Eventf("MultipleVersions", "multiple versions found, probably in transition: %v", strings.Join(images.List(), ","))

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -18,6 +17,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/api"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -44,9 +44,10 @@ func init() {
 }
 
 type StaticResourceController struct {
-	name      string
-	manifests resourceapply.AssetFunc
-	files     []string
+	name                   string
+	manifests              resourceapply.AssetFunc
+	files                  []string
+	ignoreNotFoundOnCreate bool
 
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
@@ -58,6 +59,9 @@ type StaticResourceController struct {
 
 // NewStaticResourceController returns a controller that maintains certain static manifests. Most "normal" types are supported,
 // but feel free to add ones we missed.  Use .AddInformer(), .AddKubeInformers(), .AddNamespaceInformer or to provide triggering conditions.
+// By default, the controller sets <name>Degraded condition on error when syncing a manifest.
+// Optionally, the controller can ignore NotFound errors. This is useful when syncing CRs for CRDs that may not yet exist
+// when the controller runs, such as ServiceMonitor.
 func NewStaticResourceController(
 	name string,
 	manifests resourceapply.AssetFunc,
@@ -79,6 +83,16 @@ func NewStaticResourceController(
 		factory: factory.New().WithInformers(operatorClient.Informer()).ResyncEvery(1 * time.Minute),
 	}
 
+	return c
+}
+
+// WithIgnoreNotFoundOnCreate makes the controller to ignore NotFound errors when applying a manifest.
+// Such error is returned by the API server when the controller tries to apply a CR for CRD
+// that has not yet been created.
+// This is useful when creating CRs for other operators that were not started yet (such as ServiceMonitors).
+// NotFound errors are reported in <name>Degraded condition, but with Degraded=false.
+func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceController {
+	c.ignoreNotFoundOnCreate = true
 	return c
 }
 
@@ -176,12 +190,23 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 	}
 
 	errors := []error{}
+	var notFoundErrorsCount int
 	directResourceResults := resourceapply.ApplyDirectly(c.clients, syncContext.Recorder(), c.manifests, c.files...)
 	for _, currResult := range directResourceResults {
+		if apierrors.IsNotFound(currResult.Error) {
+			notFoundErrorsCount++
+		}
 		if currResult.Error != nil {
 			errors = append(errors, fmt.Errorf("%q (%T): %v", currResult.File, currResult.Type, currResult.Error))
 			continue
 		}
+	}
+
+	cnd := operatorv1.OperatorCondition{
+		Type:    fmt.Sprintf("%sDegraded", c.name),
+		Status:  operatorv1.ConditionFalse,
+		Reason:  "AsExpected",
+		Message: "",
 	}
 
 	if len(errors) > 0 {
@@ -189,32 +214,21 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 		for _, err := range errors {
 			message = message + err.Error() + "\n"
 		}
-		errors = append(errors,
-			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    fmt.Sprintf("%sDegraded", c.name),
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "SyncError",
-				Message: message,
-			})))...,
-		)
-	} else {
-		errors = append(errors,
-			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:   fmt.Sprintf("%sDegraded", c.name),
-				Status: operatorv1.ConditionFalse,
-				Reason: "AsExpected",
-			})))...,
-		)
+		cnd.Status = operatorv1.ConditionTrue
+		cnd.Message = message
+		cnd.Reason = "SyncError"
+
+		if c.ignoreNotFoundOnCreate && len(errors) == notFoundErrorsCount {
+			// all errors were NotFound
+			cnd.Status = operatorv1.ConditionFalse
+		}
 	}
 
-	return utilerrors.NewAggregate(errors)
-}
-
-func appendErrors(_ *operatorv1.OperatorStatus, _ bool, err error) []error {
+	_, _, err = v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cnd))
 	if err != nil {
-		return []error{err}
+		errors = append(errors, err)
 	}
-	return []error{}
+	return utilerrors.NewAggregate(errors)
 }
 
 func (c *StaticResourceController) Name() string {

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/args.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/args.go
@@ -1,0 +1,61 @@
+package v1helpers
+
+import (
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// FlagsFromUnstructured process the unstructured arguments usually retrieved from an operator's configuration file under a specific key.
+// There are only two supported/valid types for arguments, that is []sting and/or string.
+// Passing a different type yield an error.
+//
+// Use ToFlagSlice function to get a slice of string flags.
+func FlagsFromUnstructured(unstructuredArgs map[string]interface{}) (map[string][]string, error) {
+	return flagsFromUnstructured(unstructuredArgs)
+}
+
+// ToFlagSlice transforms the provided arguments to a slice of string flags.
+// A flag name is taken directly from the key and the value is simply attached.
+// A flag is repeated iff it has more than one value.
+func ToFlagSlice(args map[string][]string) []string {
+	var keys []string
+	for key := range args {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var flags []string
+	for _, key := range keys {
+		for _, token := range args[key] {
+			flags = append(flags, fmt.Sprintf("--%s=%s", key, token))
+		}
+	}
+	return flags
+}
+
+// flagsFromUnstructured process the unstructured arguments (interface{}) to a map of strings.
+// There are only two supported/valid types for arguments, that is []sting and/or string.
+// Passing a different type yield an error.
+func flagsFromUnstructured(unstructuredArgs map[string]interface{}) (map[string][]string, error) {
+	ret := map[string][]string{}
+	for argName, argRawValue := range unstructuredArgs {
+		var argsSlice []string
+		var found bool
+		var err error
+
+		argsSlice, found, err = unstructured.NestedStringSlice(unstructuredArgs, argName)
+		if !found || err != nil {
+			str, found, err := unstructured.NestedString(unstructuredArgs, argName)
+			if !found || err != nil {
+				return nil, fmt.Errorf("unable to process an argument, incorrect value %v under %v key, expected []string or string", argRawValue, argName)
+			}
+			argsSlice = append(argsSlice, str)
+		}
+
+		ret[argName] = argsSlice
+	}
+
+	return ret, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+# github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
* openshift/library-go@5df90a2a: provides CancelRequest method for the PreferredHost round tripper  to facilitate cancellation
* openshift/library-go@f2434558: changes to lib-go for operator use
* openshift/library-go@9c9b6ed0: Allow StaticResourceController to ignore NotFound
* openshift/library-go@e2421125: Add ServiceMonitor sync to CSI operators
* openshift/library-go@04e8cf0b: Add ServiceMonitor to ApplyDirectly
* openshift/library-go@5cf97eb2: Return errors from ApplyDirectly
* openshift/library-go@73c4ea10: static-pods: allow fast-forward to next revision with pending installer
* openshift/library-go@d6342ca9: static-pods: avoid noise from 'for <duration>' messages
* openshift/library-go@2b890d20: convenience functions for processing unstructured arguments
* openshift/library-go@8c6d5ea6: static-pods: always set installer reason string
* openshift/library-go@4b38a49d: static-pods: no MissingVersion event as long as there are no known nodes yet
* openshift/library-go@4bcf4290: Add ${KUBE_RBAC_PROXY_IMAGE} replacer to CSI driver controller
* openshift/library-go@c4e19f3e: allow static resource controller to set degraded on panic
* openshift/library-go@e433a6cd: factory workers should always restart