### PR TITLE
DO NOT MERGE: Rotate every 15m instead of 720h

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -27,7 +27,7 @@ extendedArguments:
   - "-bootstrapsigner"
   - "-tokencleaner"
   experimental-cluster-signing-duration:
-  - "720h"
+  - "15m"
   secure-port:
   - "10257"
   port:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -135,7 +135,7 @@ extendedArguments:
   - "-bootstrapsigner"
   - "-tokencleaner"
   experimental-cluster-signing-duration:
-  - "720h"
+  - "15m"
   secure-port:
   - "10257"
   port:


### PR DESCRIPTION
Only for testing, not intended to merge. Trying to flush out the
issue related to `tls: internal error` when connecting to the kubelet
for exec sessions post-rebase / go 1.16