### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -8,7 +8,7 @@ metadata:
     openshift.io/component: "controller-manager"
   annotations:
     openshift.io/run-level: "0"
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/bindata/v4.1.0/kube-controller-manager/pod.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/pod.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-controller-manager
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: kube-controller-manager
     kube-controller-manager: "true"

--- a/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
@@ -11,7 +11,7 @@ data:
       name: recycler-pod
       namespace: openshift-infra
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       activeDeadlineSeconds: 60
       restartPolicy: Never

--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       name: kube-controller-manager-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-controller-manager-operator
     spec:

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -763,7 +763,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-controller-manager
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: kube-controller-manager
     kube-controller-manager: "true"
@@ -961,7 +961,7 @@ data:
       name: recycler-pod
       namespace: openshift-infra
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       activeDeadlineSeconds: 60
       restartPolicy: Never


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please