### PR TITLE
Bug 1954790: Use appropriate metric for PDB alerts

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -23,7 +23,7 @@ spec:
           annotations:
             message: The pod disruption budget is preventing further disruption to pods because it is at the minimum allowed level.
           expr: |
-            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_expected_pods == kube_poddisruptionbudget_status_desired_healthy)
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy)
           for: 15m
           labels:
             severity: warning
@@ -31,7 +31,7 @@ spec:
           annotations:
             message: The pod disruption budget is below the minimum number allowed pods.
           expr: |
-            max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_expected_pods < kube_poddisruptionbudget_status_desired_healthy)
+            max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy < kube_poddisruptionbudget_status_desired_healthy)
           for: 15m
           labels:
             severity: critical


### PR DESCRIPTION
As of now, we are using `kube_poddisruptionbudget_status_expected_pods`
metric to decide if the PDB is its limit or it exceeded where as
`kube_poddisruptionbudget_status_current_healthy` metric
gives the exact number of healthy replicas for a
deployment or other workload that can scale. So,
changing the alerts to use correct metric so that we
don't get unnecessary signals.

cc @soltysh @smarterclayton 