### PR TITLE
Bug 1954790: Revert use appropriate metric for PDB alerts

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -23,7 +23,7 @@ spec:
           annotations:
             message: The pod disruption budget is preventing further disruption to pods because it is at the minimum allowed level.
           expr: |
-            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy)
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_expected_pods == kube_poddisruptionbudget_status_desired_healthy)
           for: 15m
           labels:
             severity: warning
@@ -31,7 +31,7 @@ spec:
           annotations:
             message: The pod disruption budget is below the minimum number allowed pods.
           expr: |
-            max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy < kube_poddisruptionbudget_status_desired_healthy)
+            max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_expected_pods < kube_poddisruptionbudget_status_desired_healthy)
           for: 15m
           labels:
             severity: critical


### PR DESCRIPTION
Reverts openshift/cluster-kube-controller-manager-operator#527

as this is blocking upgrades and needs deeper discussion on how to avoid firing this alert during upgrades.