### PR TITLE
Bug 1954790: pdb: Increase PDBAtLimit timeout

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -24,7 +24,7 @@ spec:
             message: The pod disruption budget is preventing further disruption to pods because it is at the minimum allowed level.
           expr: |
             max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy)
-          for: 15m
+          for: 60m
           labels:
             severity: warning
         - alert: PodDisruptionBudgetLimit


### PR DESCRIPTION
Increase the timeout for PodDisruptionBudgetAtLimit
alert as this warning level and as per the conventions
mentioned at:

https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#warning-alerts

In future, we can have separate alerts for OCP specific components
and user workload specific components.