### PR TITLE
Bug 1965562: recycler-for-nfs-... does not set requests or priorityClassName

### DIFF
--- a/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
+++ b/bindata/v4.1.0/kube-controller-manager/recycler-cm.yaml
@@ -29,5 +29,10 @@ data:
               name: vol
           securityContext:
             runAsUser: 0
+          priorityClassName: openshift-user-critical
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: vol

--- a/pkg/operator/v411_00_assets/bindata.go
+++ b/pkg/operator/v411_00_assets/bindata.go
@@ -979,6 +979,11 @@ data:
               name: vol
           securityContext:
             runAsUser: 0
+          priorityClassName: openshift-user-critical
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: vol
 `)


### PR DESCRIPTION
See the bug for details:
https://bugzilla.redhat.com/show_bug.cgi?id=1965562

`openshift-user-critical` seems ok to me, and the request sizes are the same as what we use on some of the CSI sidecars:
https://github.com/openshift/aws-ebs-csi-driver-operator/blob/master/assets/controller.yaml#L284-L287
This container is _very_ ephemeral (as in, typically can't catch it running without adding a sleep). It just removes files from an NFS volume after it's deleted, when `persistentVolumeReclaimPolicy: Recycle` is set on the PV.

@openshift/storage @wking : any other thoughts or feedback on the requests or priority class?