### PR TITLE
update cluster-policy-controller configuration

### DIFF
--- a/bindata/assets/kube-controller-manager/pod.yaml
+++ b/bindata/assets/kube-controller-manager/pod.yaml
@@ -70,6 +70,15 @@ spec:
       initialDelaySeconds: 10
       timeoutSeconds: 10
   - name: cluster-policy-controller
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     image: ${CLUSTER_POLICY_CONTROLLER_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -78,7 +87,9 @@ spec:
       - |
         timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10357 \))" ]; do sleep 1; done'
 
-        exec cluster-policy-controller start --config=/etc/kubernetes/static-pod-resources/configmaps/cluster-policy-controller-config/config.yaml
+        exec cluster-policy-controller start --config=/etc/kubernetes/static-pod-resources/configmaps/cluster-policy-controller-config/config.yaml \
+          --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig \
+          --namespace=${POD_NAMESPACE}
     resources:
       requests:
         memory: 200Mi

--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -64,11 +64,22 @@ spec:
       initialDelaySeconds: 45
       timeoutSeconds: 10
   - name: cluster-policy-controller
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     image: {{ .ClusterPolicyControllerImage }}
     imagePullPolicy: {{ .ImagePullPolicy }}
     command: ["cluster-policy-controller", "start"]
     args:
     - --config=/etc/kubernetes/config/{{ .ClusterPolicyControllerConfigFileName }}
+    - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - --namespace=$(POD_NAMESPACE)
     - --logtostderr=false
     - --alsologtostderr
     - --v=2


### PR DESCRIPTION
this is required for cluster-policy-controller refactoring: https://github.com/openshift/cluster-policy-controller/pull/65

- pass pod metadata and kubeconfig to the controller
- add new role for getting pods (required by event recorder)