### PR TITLE
fix clusterroles for the CSR approver

### DIFF
--- a/bindata/assets/kube-controller-manager/csr_approver_clusterrole.yaml
+++ b/bindata/assets/kube-controller-manager/csr_approver_clusterrole.yaml
@@ -6,15 +6,27 @@ metadata:
   name: system:openshift:controller:cluster-csr-approver-controller
 rules:
   - apiGroups:
-      - certificates.k8s.io
+    - certificates.k8s.io
     resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
+    - certificatesigningrequests
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - certificates.k8s.io
+    resources:
+    - certificatesigningrequests/approval
+    verbs:
+    - update
+  - apiGroups:
+    - certificates.k8s.io
+    resources:
+    - signers
+    resourceNames:
+    - kubernetes.io/kube-apiserver-client
+    verbs:
+    - approve
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
The current clusterroles don't allow the CSR approver to change the approval status of a CSR or approve the CSR requested to be signed by the `kubernetes.io/kube-apiserver-client`. The approver needs to be able to do those things, though.

/assignm @slaskawi 