### PR TITLE
Cloud Volume Observer: Extended arguments must be a slice

### DIFF
--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
@@ -20,12 +20,8 @@ func ObserveCloudVolumePlugin(genericListers configobserver.Listers, recorder ev
 	}()
 	prevObservedConfig := map[string]interface{}{}
 
-	currentCloudVolumePlugin, _, err := unstructured.NestedString(existingConfig, volumePluginPath...)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	if len(currentCloudVolumePlugin) > 0 {
-		if err := unstructured.SetNestedField(prevObservedConfig, currentCloudVolumePlugin, volumePluginPath...); err != nil {
+	if currentCloudVolumePlugin, _, _ := unstructured.NestedStringSlice(existingConfig, volumePluginPath...); len(currentCloudVolumePlugin) > 0 {
+		if err := unstructured.SetNestedStringSlice(prevObservedConfig, currentCloudVolumePlugin, volumePluginPath...); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -46,7 +42,7 @@ func ObserveCloudVolumePlugin(genericListers configobserver.Listers, recorder ev
 
 	// If the cloud provider is external, we should set the option, else leave it empty.
 	if external && len(cloudProvider) > 0 {
-		if err := unstructured.SetNestedField(observedConfig, cloudProvider, volumePluginPath...); err != nil {
+		if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, volumePluginPath...); err != nil {
 			recorder.Warningf("ObserveCloudVolumePlugin", "Failed setting cloudVolumePlugin: %v", err)
 			return existingConfig, append(errs, err)
 		}

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
@@ -52,7 +52,7 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			map[string]interface{}{},
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": "aws",
+					"external-cloud-volume-plugin": []interface{}{"aws"},
 				}},
 			false,
 		},
@@ -62,7 +62,7 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			nil,
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": "aws",
+					"external-cloud-volume-plugin": []interface{}{"aws"},
 				}},
 			map[string]interface{}{},
 			false,


### PR DESCRIPTION
Merging #525 appears to have broken the KCMO when it comes to setting this new flag

```
Operator degraded (TargetConfigController_SynchronizationError): TargetConfigControllerDegraded: "configmap": error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field KubeControllerManagerConfig.extendedArguments of type v1.Arguments
```

Based on the other extended arguments observers, I've updated the observer here. Testing on a real cluster now, will report back shortly.