### PR TITLE
remove unused cluster-policy-controller configuration

### DIFF
--- a/bindata/assets/config/default-cluster-policy-controller-config.yaml
+++ b/bindata/assets/config/default-cluster-policy-controller-config.yaml
@@ -1,11 +1,8 @@
 apiVersion: openshiftcontrolplane.config.openshift.io/v1
 kind: OpenShiftControllerManagerConfig
-kubeClientConfig:
-  kubeConfig: /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
 servingInfo:
   bindAddress: 0.0.0.0:10357
   bindNetwork: tcp
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key
-

--- a/bindata/bootkube/config/bootstrap-cluster-policy-controller-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-cluster-policy-controller-config-overrides.yaml
@@ -1,7 +1,5 @@
 apiVersion: openshiftcontrolplane.config.openshift.io/v1
 kind: OpenShiftControllerManagerConfig
-kubeClientConfig:
-  kubeConfig: /etc/kubernetes/secrets/kubeconfig
 servingInfo:
   clientCA: /etc/kubernetes/secrets/kube-control-plane-ca-bundle.crt
   certFile: /etc/kubernetes/secrets/kube-control-plane-kube-controller-manager-client.crt


### PR DESCRIPTION
remove configuration that was made obsolete by recent cluster-policy-controller updates https://github.com/openshift/cluster-kube-controller-manager-operator/pull/545 and https://github.com/openshift/cluster-policy-controller/pull/65 