### PR TITLE
collect metrics for cluster-policy-controller

### DIFF
--- a/bindata/assets/kube-controller-manager/svc-cluster-policy-controller.yaml
+++ b/bindata/assets/kube-controller-manager/svc-cluster-policy-controller.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: openshift-kube-controller-manager
-  name: kube-controller-manager
+  name: cluster-policy-controller
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: serving-cert-cpc
   labels:
-    prometheus: "kube-controller-manager"
+    prometheus: "cluster-policy-controller"
 spec:
   selector:
     kube-controller-manager: "true"
   ports:
   - name: https
-    port: 10257
-    targetPort: 10257
+    port: 10357
+    targetPort: 10357

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -75,4 +75,48 @@ spec:
   namespaceSelector:
     matchNames:
     - openshift-kube-controller-manager
-  selector: {}
+  selector:
+    matchLabels:
+      prometheus: kube-controller-manager
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kube-controller-manager
+  name: cluster-policy-controller
+  namespace: openshift-kube-controller-manager
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|request|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: rest_client_request_latency_seconds_(bucket|count|sum)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)
+          sourceLabels:
+            - __name__
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: kube-controller-manager.openshift-kube-controller-manager.svc
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+  namespaceSelector:
+    matchNames:
+      - openshift-kube-controller-manager
+  selector:
+    matchLabels:
+      prometheus: cluster-policy-controller

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -89,6 +89,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			"assets/kube-controller-manager/namespace-security-allocation-controller-clusterrole.yaml",
 			"assets/kube-controller-manager/namespace-security-allocation-controller-clusterrolebinding.yaml",
 			"assets/kube-controller-manager/svc.yaml",
+			"assets/kube-controller-manager/svc-cluster-policy-controller.yaml",
 			"assets/kube-controller-manager/sa.yaml",
 			"assets/kube-controller-manager/localhost-recovery-client-crb.yaml",
 			"assets/kube-controller-manager/localhost-recovery-sa.yaml",


### PR DESCRIPTION
updates the ServiceMonitor so it also collects metrics from cluster-policy-controller. 

This will start working after the correct ports get opened on the nodes - see installer PR


TODO:
- [x] https://github.com/openshift/installer/pull/5105