### PR TITLE
Bug 1986829: metrics: use client cert auth for metrics scraping

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
@@ -21,6 +21,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-kube-controller-manager-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   namespaceSelector:
     matchNames:

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -70,6 +70,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: kube-controller-manager.openshift-kube-controller-manager.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   namespaceSelector:
     matchNames:
     - openshift-kube-controller-manager


### PR DESCRIPTION
The CMO is now capable of using client cert auth to scrape the metrics endpoints. Use that in our components to reduce API load and allow metrics collection when the API is down - given further authz conditions are met.