### PR TITLE
podsecurity: enforce privileged for openshift-kube-controller-manager namespace

### DIFF
--- a/bindata/assets/kube-controller-manager/ns.yaml
+++ b/bindata/assets/kube-controller-manager/ns.yaml
@@ -8,3 +8,6 @@ metadata:
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-kube-controller-manager` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @deads2k @sttts 