### PR TITLE
bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20211108165917-be1be0e89115
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83
-	github.com/openshift/library-go v0.0.0-20210930103404-8911cacccb05
+	github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6
 	github.com/prometheus/common v0.26.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83 h1:TGBy40xVBCqDqvu8gaakva4u+08JtOt/LfekiwbCMyc=
 github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83/go.mod h1:iSeqKIqUKxVec3gV1kNvwS1tjDpzpdP134RimkLc3BE=
-github.com/openshift/library-go v0.0.0-20210930103404-8911cacccb05 h1:fqacx32b0XdTNe5yU6rvkkI9UPl1R2ztN8vXWy/6/8U=
-github.com/openshift/library-go v0.0.0-20210930103404-8911cacccb05/go.mod h1:b1cKE6TuNqjl7wT0y3W4g0qREuab1mH6WOJm9pT8L/A=
+github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6 h1:dAwIJESWIaTAJoWUIAZbMgJIGvMIbBeuKSa/256Tl58=
+github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6/go.mod h1:b1cKE6TuNqjl7wT0y3W4g0qREuab1mH6WOJm9pT8L/A=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/operator/certrotationcontroller/satokensigner_controller.go
+++ b/pkg/operator/certrotationcontroller/satokensigner_controller.go
@@ -72,7 +72,7 @@ func (c *SATokenSignerController) sync(ctx context.Context, syncCtx factory.Sync
 		condition.Reason = "Error"
 		condition.Message = syncErr.Error()
 	}
-	if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(condition)); updateErr != nil {
+	if _, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(condition)); updateErr != nil {
 		return updateErr
 	}
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -111,7 +111,7 @@ func NewTargetConfigController(
 }
 
 func (c TargetConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorStateWithQuorum()
+	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorStateWithQuorum(ctx)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func createTargetConfigController(ctx context.Context, syncCtx factory.SyncConte
 			Status: operatorv1.ConditionTrue,
 		}
 	}
-	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(upgradeableCondition)); err != nil {
+	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(upgradeableCondition)); err != nil {
 		return true, err
 	}
 
@@ -291,13 +291,13 @@ func createTargetConfigController(ctx context.Context, syncCtx factory.SyncConte
 			Reason:  "SynchronizationError",
 			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
 		}
-		if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
+		if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
 			return true, err
 		}
 		return true, nil
 	}
 
-	if err = setCloudControllerOwnerCondition(c); err != nil {
+	if err = setCloudControllerOwnerCondition(ctx, c); err != nil {
 		return true, err
 	}
 
@@ -305,7 +305,7 @@ func createTargetConfigController(ctx context.Context, syncCtx factory.SyncConte
 		Type:   "TargetConfigControllerDegraded",
 		Status: operatorv1.ConditionFalse,
 	}
-	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
+	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
 		return true, err
 	}
 
@@ -315,7 +315,7 @@ func createTargetConfigController(ctx context.Context, syncCtx factory.SyncConte
 // setCloudControllerOwnerCondition sets the condition to False if either external cloud
 // provider has been successfully applied for all static pods or it's not set at all. Otherwise
 // it sets the condition to True.
-func setCloudControllerOwnerCondition(c TargetConfigController) error {
+func setCloudControllerOwnerCondition(ctx context.Context, c TargetConfigController) error {
 	_, status, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return fmt.Errorf("could not get operator state: %v", err)
@@ -352,7 +352,7 @@ func setCloudControllerOwnerCondition(c TargetConfigController) error {
 		}
 	}
 
-	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond)); err != nil {
+	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond)); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -33,8 +33,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 			return true, nil
 		}
 		return isExternalFeatureGateEnabled(featureGate)
-	case configv1.IBMCloudPlatformType,
-		configv1.AlibabaCloudPlatformType:
+	case configv1.IBMCloudPlatformType, configv1.AlibabaCloudPlatformType, configv1.PowerVSPlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
@@ -226,7 +226,7 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 		return reportedError
 	}
 	if reportedError != nil {
-		_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    c.name + "Degraded",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "SyncError",
@@ -237,7 +237,7 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 		}
 		return reportedError
 	}
-	_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient,
+	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.syncDegradedClient,
 		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:   c.name + "Degraded",
 			Status: operatorv1.ConditionFalse,

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -94,7 +94,7 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 		newCondition.Reason = "RotationError"
 		newCondition.Message = syncErr.Error()
 	}
-	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(ctx, c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
 	if updateErr != nil {
 		return updateErr
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - tkashem
+  - p0lyn0mial
+  - sttts
+approvers:
+  - tkashem
+  - p0lyn0mial
+  - sttts

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -193,6 +193,7 @@ func GetPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 	case configv1.OvirtPlatformType:
 	case configv1.KubevirtPlatformType:
 	case configv1.AlibabaCloudPlatformType:
+	case configv1.PowerVSPlatformType:
 	default:
 		// the new doc on the infrastructure fields requires that we treat an unrecognized thing the same bare metal.
 		// TODO find a way to indicate to the user that we didn't honor their choice

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
@@ -159,7 +159,7 @@ func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) e
 		errs = append(errs, errors.New("non-deterministic config observation detected"))
 	}
 
-	if err := c.updateObservedConfig(syncCtx, existingConfig, mergedObservedConfig); err != nil {
+	if err := c.updateObservedConfig(ctx, syncCtx, existingConfig, mergedObservedConfig); err != nil {
 		errs = []error{err}
 	}
 	configError := v1helpers.NewMultiLineAggregate(errs)
@@ -174,18 +174,18 @@ func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) e
 		cond.Reason = "Error"
 		cond.Message = configError.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 
 	return configError
 }
 
-func (c ConfigObserver) updateObservedConfig(syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
+func (c ConfigObserver) updateObservedConfig(ctx context.Context, syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
 	if len(c.nestedConfigPath) == 0 {
 		if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
 			syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
-			return c.updateConfig(syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
+			return c.updateConfig(ctx, syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
 		}
 		return nil
 	}
@@ -200,15 +200,15 @@ func (c ConfigObserver) updateObservedConfig(syncCtx factory.SyncContext, existi
 	}
 	if !equality.Semantic.DeepEqual(existingConfigNested, mergedObservedConfigNested) {
 		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated section (%q) of observed config: %q", strings.Join(c.nestedConfigPath, "/"), diff.ObjectDiff(existingConfigNested, mergedObservedConfigNested))
-		return c.updateConfig(syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
+		return c.updateConfig(ctx, syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
 	}
 	return nil
 }
 
 type updateObservedConfigFn func(config map[string]interface{}) v1helpers.UpdateOperatorSpecFunc
 
-func (c ConfigObserver) updateConfig(syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
-	if _, _, err := v1helpers.UpdateSpec(c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
+func (c ConfigObserver) updateConfig(ctx context.Context, syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
+	if _, _, err := v1helpers.UpdateSpec(ctx, c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
 		// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
 		// but instead reset the errors and only report single error condition.
 		syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/proxy/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/proxy/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- stlaz
+approvers:
+- stlaz

--- a/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -104,7 +104,7 @@ func (c dynamicOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *op
 // UpdateOperatorSpec overwrites the operator object spec with the values given
 // in operatorv1.OperatorSpec while preserving pre-existing spec fields that have
 // no correspondence in operatorv1.OperatorSpec.
-func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
+func (c dynamicOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
 	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, "", err
@@ -117,7 +117,7 @@ func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *
 		return nil, "", err
 	}
 
-	ret, err := c.client.Update(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.Update(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -132,7 +132,7 @@ func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *
 // UpdateOperatorStatus overwrites the operator object status with the values given
 // in operatorv1.OperatorStatus while preserving pre-existing status fields that have
 // no correspondence in operatorv1.OperatorStatus.
-func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c dynamicOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, stat
 		return nil, err
 	}
 
-	ret, err := c.client.UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.UpdateStatus(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, stat
 	return retStatus, nil
 }
 
-func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
+func (c dynamicOperatorClient) EnsureFinalizer(ctx context.Context, finalizer string) error {
 	uncastInstance, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return err
@@ -174,7 +174,7 @@ func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
 	// Change is needed
 	klog.V(4).Infof("Adding finalizer %q", finalizer)
 	newFinalizers := append(finalizers, finalizer)
-	err = c.saveFinalizers(instance, newFinalizers)
+	err = c.saveFinalizers(ctx, instance, newFinalizers)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
 	return err
 }
 
-func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
+func (c dynamicOperatorClient) RemoveFinalizer(ctx context.Context, finalizer string) error {
 	uncastInstance, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return err
@@ -204,7 +204,7 @@ func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
 	}
 
 	klog.V(4).Infof("Removing finalizer %q: %v", finalizer, newFinalizers)
-	err = c.saveFinalizers(instance, newFinalizers)
+	err = c.saveFinalizers(ctx, instance, newFinalizers)
 	if err != nil {
 		return err
 	}
@@ -212,10 +212,10 @@ func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
 	return nil
 }
 
-func (c dynamicOperatorClient) saveFinalizers(instance *unstructured.Unstructured, finalizers []string) error {
+func (c dynamicOperatorClient) saveFinalizers(ctx context.Context, instance *unstructured.Unstructured, finalizers []string) error {
 	clone := instance.DeepCopy()
 	clone.SetFinalizers(finalizers)
-	_, err := c.client.Update(context.TODO(), clone, metav1.UpdateOptions{})
+	_, err := c.client.Update(ctx, clone, metav1.UpdateOptions{})
 	return err
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
@@ -60,8 +60,8 @@ func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1
 	return spec, status, instance.GetResourceVersion(), nil
 }
 
-func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
-	instance, err := c.client.Get(context.TODO(), "cluster", metav1.GetOptions{})
+func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum(ctx context.Context) (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
+	instance, err := c.client.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -78,7 +78,7 @@ func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum() (*
 	return spec, status, instance.GetResourceVersion(), nil
 }
 
-func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
+func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
 	uncastOriginal, err := c.informer.Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
@@ -91,7 +91,7 @@ func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVers
 		return nil, "", err
 	}
 
-	ret, err := c.client.Update(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.Update(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -103,7 +103,7 @@ func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVers
 	return retSpec, ret.GetResourceVersion(), nil
 }
 
-func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
+func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
 	uncastOriginal, err := c.informer.Lister().Get("cluster")
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVe
 		return nil, err
 	}
 
-	ret, err := c.client.UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.UpdateStatus(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
@@ -42,3 +42,15 @@ func ApplyCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.
 
 	return actual, true, err
 }
+
+func DeleteCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, bool, error) {
+	err := client.CustomResourceDefinitions().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -455,3 +455,75 @@ func deleteSecretSyncTarget(ctx context.Context, client coreclientv1.SecretsGett
 	}
 	return false, err
 }
+
+func DeleteNamespace(ctx context.Context, client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
+	err := client.Namespaces().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteService(ctx context.Context, client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
+	err := client.Services(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeletePod(ctx context.Context, client coreclientv1.PodsGetter, recorder events.Recorder, required *corev1.Pod) (*corev1.Pod, bool, error) {
+	err := client.Pods(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteServiceAccount(ctx context.Context, client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
+	err := client.ServiceAccounts(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
+	err := client.ConfigMaps(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
+	err := client.Secrets(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -55,6 +55,10 @@ type ApplyResult struct {
 	Error   error
 }
 
+// ConditionalFunction provides needed dependency for a resource on another condition instead of blindly creating
+// a resource. This conditional function can also be used to delete the resource when not needed
+type ConditionalFunction func() bool
+
 type ClientHolder struct {
 	kubeClient          kubernetes.Interface
 	apiExtensionsClient apiextensionsclient.Interface
@@ -227,6 +231,135 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 				result.Error = fmt.Errorf("missing dynamicClient")
 			} else {
 				result.Result, result.Changed, result.Error = ApplyKnownUnstructured(ctx, clients.dynamicClient, recorder, t)
+			}
+		default:
+			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
+		}
+
+		ret = append(ret, result)
+	}
+
+	return ret
+}
+
+func DeleteAll(ctx context.Context, clients *ClientHolder, recorder events.Recorder, manifests AssetFunc,
+	files ...string) []ApplyResult {
+	ret := []ApplyResult{}
+
+	for _, file := range files {
+		result := ApplyResult{File: file}
+		objBytes, err := manifests(file)
+		if err != nil {
+			result.Error = fmt.Errorf("missing %q: %v", file, err)
+			ret = append(ret, result)
+			continue
+		}
+		requiredObj, err := decode(objBytes)
+		if err != nil {
+			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)
+			ret = append(ret, result)
+			continue
+		}
+		result.Type = fmt.Sprintf("%T", requiredObj)
+		// NOTE: Do not add CR resources into this switch otherwise the protobuf client can cause problems.
+		switch t := requiredObj.(type) {
+		case *corev1.Namespace:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteNamespace(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.Service:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteService(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.Pod:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeletePod(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.ServiceAccount:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteServiceAccount(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.ConfigMap:
+			client := clients.configMapsGetter()
+			if client == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteConfigMap(ctx, client, recorder, t)
+			}
+		case *corev1.Secret:
+			client := clients.secretsGetter()
+			if client == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteSecret(ctx, client, recorder, t)
+			}
+		case *rbacv1.ClusterRole:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteClusterRole(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *rbacv1.ClusterRoleBinding:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteClusterRoleBinding(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *rbacv1.Role:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteRole(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *rbacv1.RoleBinding:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteRoleBinding(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *policyv1.PodDisruptionBudget:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeletePodDisruptionBudget(ctx, clients.kubeClient.PolicyV1(), recorder, t)
+			}
+		case *apiextensionsv1.CustomResourceDefinition:
+			if clients.apiExtensionsClient == nil {
+				result.Error = fmt.Errorf("missing apiExtensionsClient")
+			} else {
+				_, result.Changed, result.Error = DeleteCustomResourceDefinitionV1(ctx, clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
+			}
+		case *storagev1.StorageClass:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteStorageClass(ctx, clients.kubeClient.StorageV1(), recorder, t)
+			}
+		case *storagev1.CSIDriver:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteCSIDriver(ctx, clients.kubeClient.StorageV1(), recorder, t)
+			}
+		case *migrationv1alpha1.StorageVersionMigration:
+			if clients.migrationClient == nil {
+				result.Error = fmt.Errorf("missing migrationClient")
+			} else {
+				_, result.Changed, result.Error = DeleteStorageVersionMigration(ctx, clients.migrationClient, recorder, t)
+			}
+		case *unstructured.Unstructured:
+			if clients.dynamicClient == nil {
+				result.Error = fmt.Errorf("missing dynamicClient")
+			} else {
+				_, result.Changed, result.Error = DeleteKnownUnstructured(ctx, clients.dynamicClient, recorder, t)
 			}
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/migration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/migration.go
@@ -44,3 +44,16 @@ func ApplyStorageVersionMigration(ctx context.Context, client migrationclientv1a
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
+
+func DeleteStorageVersionMigration(ctx context.Context, client migrationclientv1alpha1.Interface, recorder events.Recorder, required *migrationv1alpha1.StorageVersionMigration) (*migrationv1alpha1.StorageVersionMigration, bool, error) {
+	clientInterface := client.MigrationV1alpha1().StorageVersionMigrations()
+	err := clientInterface.Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/policy.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/policy.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policyclientv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -46,4 +45,16 @@ func ApplyPodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisr
 	actual, err := client.PodDisruptionBudgets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func DeletePodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisruptionBudgetsGetter, recorder events.Recorder, required *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, bool, error) {
+	err := client.PodDisruptionBudgets(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/klog/v2"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -196,4 +195,52 @@ func ApplyRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGette
 	actual, err := client.RoleBindings(requiredCopy.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, requiredCopy, err)
 	return actual, true, err
+}
+
+func DeleteClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGetter, recorder events.Recorder, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
+	err := client.ClusterRoles().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteClusterRoleBinding(ctx context.Context, client rbacclientv1.ClusterRoleBindingsGetter, recorder events.Recorder, required *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error) {
+	err := client.ClusterRoleBindings().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteRole(ctx context.Context, client rbacclientv1.RolesGetter, recorder events.Recorder, required *rbacv1.Role) (*rbacv1.Role, bool, error) {
+	err := client.Roles(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGetter, recorder events.Recorder, required *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
+	err := client.RoleBindings(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -3,8 +3,6 @@ package resourceapply
 import (
 	"context"
 
-	"k8s.io/klog/v2"
-
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -12,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
 	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -120,4 +119,29 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func DeleteStorageClass(ctx context.Context, client storageclientv1.StorageClassesGetter, recorder events.Recorder, required *storagev1.StorageClass) (*storagev1.StorageClass, bool,
+	error) {
+	err := client.StorageClasses().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+	err := client.CSIDrivers().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
@@ -25,3 +25,18 @@ func ApplyKnownUnstructured(ctx context.Context, client dynamic.Interface, recor
 
 	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())
 }
+
+// DeleteKnownUnstructured deletes few selected Unstructured types
+func DeleteKnownUnstructured(ctx context.Context, client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}:
+		return DeleteServiceMonitor(ctx, client, recorder, obj)
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "PrometheusRule"}:
+		return DeletePrometheusRule(ctx, client, recorder, obj)
+	case schema.GroupKind{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshotClass"}:
+		return DeleteVolumeSnapshotClass(ctx, client, recorder, obj)
+
+	}
+
+	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/volumesnapshotclass.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/volumesnapshotclass.go
@@ -114,3 +114,16 @@ func ApplyVolumeSnapshotClass(ctx context.Context, client dynamic.Interface, rec
 	recorder.Eventf("VolumeSnapshotClassUpdated", "Updated VolumeSnapshotClass.snapshot.storage.k8s.io/v1 because it changed")
 	return newObj, true, err
 }
+
+func DeleteVolumeSnapshotClass(ctx context.Context, client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	namespace := required.GetNamespace()
+	err := client.Resource(volumeSnapshotClassResourceGVR).Namespace(namespace).Delete(ctx, required.GetName(), metav1.DeleteOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -218,7 +218,7 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 			Reason:  "Error",
 			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
 		}
-		if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 			return updateError
 		}
 		return nil
@@ -228,7 +228,7 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 		Type:   condition.ResourceSyncControllerDegradedConditionType,
 		Status: operatorv1.ConditionFalse,
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 	return nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - p0lyn0mial
+  - sttts
+approvers:
+  - p0lyn0mial
+  - sttts

--- a/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
@@ -36,7 +36,7 @@ func (c RemoveStaleConditionsController) sync(ctx context.Context, syncContext f
 		return nil
 	}
 
-	if _, _, err := v1helpers.UpdateStatus(c.operatorClient, removeStaleConditionsFn); err != nil {
+	if _, _, err := v1helpers.UpdateStatus(ctx, c.operatorClient, removeStaleConditionsFn); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - p0lyn0mial
+  - sttts
+approvers:
+  - p0lyn0mial
+  - sttts

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -498,7 +498,7 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 			// it's an extra write/read, but it makes the state debuggable from outside this process
 			if !equality.Semantic.DeepEqual(newCurrNodeState, currNodeState) {
 				klog.Infof("%q moving to %v because %s", currNodeState.NodeName, spew.Sdump(*newCurrNodeState), reason)
-				_, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions)
+				_, updated, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions)
 				if updateError != nil {
 					return false, 0, updateError
 				} else if updated && currNodeState.CurrentRevision != newCurrNodeState.CurrentRevision {
@@ -530,7 +530,7 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 		// it's an extra write/read, but it makes the state debuggable from outside this process
 		if !equality.Semantic.DeepEqual(newCurrNodeState, currNodeState) {
 			klog.Infof("%q moving to %v", currNodeState.NodeName, spew.Sdump(*newCurrNodeState))
-			if _, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
+			if _, updated, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
 				return false, 0, updateError
 			} else if updated && currNodeState.TargetRevision != newCurrNodeState.TargetRevision && newCurrNodeState.TargetRevision != 0 {
 				c.eventRecorder.Eventf("NodeTargetRevisionChanged", "Updating node %q from revision %d to %d because %s", currNodeState.NodeName,
@@ -561,7 +561,6 @@ func setNodeStatusFn(status *operatorv1.NodeStatus) v1helpers.UpdateStaticPodSta
 func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1.StaticPodOperatorStatus) error {
 	// Available means that we have at least one pod at the latest level
 	numAvailable := 0
-	numAtLatestRevision := 0
 	numProgressing := 0
 	counts := map[int32]int{}
 	failingCount := map[int32]int{}
@@ -580,9 +579,7 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 			failing[currNodeStatus.LastFailedRevision] = append(failing[currNodeStatus.LastFailedRevision], currNodeStatus.LastFailedRevisionErrors...)
 		}
 
-		if newStatus.LatestAvailableRevision == currNodeStatus.CurrentRevision {
-			numAtLatestRevision += 1
-		} else {
+		if newStatus.LatestAvailableRevision != currNodeStatus.CurrentRevision {
 			numProgressing += 1
 		}
 	}
@@ -1084,7 +1081,7 @@ func (c InstallerController) Sync(ctx context.Context, syncCtx factory.SyncConte
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
 		if err == nil {
 			return updateError
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
@@ -105,7 +105,7 @@ func (c *InstallerStateController) sync(ctx context.Context, syncCtx factory.Syn
 		updateConditionFuncs = append(updateConditionFuncs, v1helpers.UpdateStaticPodConditionFn(updatedCondition))
 	}
 
-	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, updateConditionFuncs...); err != nil {
+	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, updateConditionFuncs...); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/node/node_controller.go
@@ -115,7 +115,7 @@ func (c NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) e
 	}
 
 	oldStatus := &operatorv1.StaticPodOperatorStatus{}
-	_, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, func(status *operatorv1.StaticPodOperatorStatus) error {
+	_, updated, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, func(status *operatorv1.StaticPodOperatorStatus) error {
 		//a hack for storing the old status (before we mutate it)
 		oldStatus = status
 		return nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/startupmonitorcondition/startup_monitor_condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/startupmonitorcondition/startup_monitor_condition.go
@@ -41,13 +41,13 @@ func New(targetNamespace string,
 	return factory.New().WithSync(fd.sync).ResyncEvery(6*time.Minute).WithInformers(kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Pods().Informer(), operatorClient.Informer()).ToController("StartupMonitorPodCondition", eventRecorder)
 }
 
-func (fd *startupMonitorPodConditionController) sync(_ context.Context, _ factory.SyncContext) (err error) {
+func (fd *startupMonitorPodConditionController) sync(ctx context.Context, _ factory.SyncContext) (err error) {
 	startupPodDegraded := &operatorv1.OperatorCondition{Type: "StartupMonitorPodDegraded", Status: operatorv1.ConditionFalse}
 	startupPodContainerExcessiveRestartsDegraded := &operatorv1.OperatorCondition{Type: "StartupMonitorPodContainerExcessiveRestartsDegraded", Status: operatorv1.ConditionFalse}
 
 	defer func() {
 		if err == nil {
-			if _, _, updateError := operatorv1helpers.UpdateStatus(fd.operatorClient,
+			if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, fd.operatorClient,
 				operatorv1helpers.UpdateConditionFn(*startupPodDegraded),
 				operatorv1helpers.UpdateConditionFn(*startupPodContainerExcessiveRestartsDegraded)); updateError != nil {
 				err = updateError

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition.go
@@ -42,11 +42,11 @@ func New(targetNamespace string,
 }
 
 // sync sets/unsets a StaticPodFallbackRevisionDegraded condition if a pod that matches the given label selector is annotated with FallbackForRevision
-func (fd *staticPodFallbackConditionController) sync(_ context.Context, _ factory.SyncContext) (err error) {
+func (fd *staticPodFallbackConditionController) sync(ctx context.Context, _ factory.SyncContext) (err error) {
 	degradedCondition := operatorv1.OperatorCondition{Type: "StaticPodFallbackRevisionDegraded", Status: operatorv1.ConditionFalse}
 	defer func() {
 		if err == nil {
-			if _, _, updateError := operatorv1helpers.UpdateStatus(fd.operatorClient, operatorv1helpers.UpdateConditionFn(degradedCondition)); updateError != nil {
+			if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, fd.operatorClient, operatorv1helpers.UpdateConditionFn(degradedCondition)); updateError != nil {
 				err = updateError
 			}
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -173,7 +173,7 @@ func (c *StaticPodStateController) sync(ctx context.Context, syncCtx factory.Syn
 		cond.Reason = "Error"
 		cond.Message = v1helpers.NewMultiLineAggregate(errs).Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -59,6 +60,8 @@ type InstallOptions struct {
 	StaticPodManifestsLockFile string
 
 	PodMutationFns []PodMutationFunc
+
+	KubeletVersion string
 }
 
 // PodMutationFunc is a function that has a chance at changing the pod before it is created
@@ -179,6 +182,14 @@ func (o *InstallOptions) nameFor(prefix string) string {
 
 func (o *InstallOptions) prefixFor(name string) string {
 	return name[0 : len(name)-len(fmt.Sprintf("-%s", o.Revision))]
+}
+
+func (o *InstallOptions) kubeletVersion(ctx context.Context) (string, error) {
+	node, err := o.KubeClient.CoreV1().Nodes().Get(ctx, o.NodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return node.Status.NodeInfo.KubeletVersion, nil
 }
 
 func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceDir string,
@@ -387,6 +398,21 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 	}
 
+	err = retry.RetryOnConnectionErrors(ctx, func(context.Context) (bool, error) {
+		version, err := o.kubeletVersion(ctx)
+		if err != nil {
+			return false, err
+		}
+		// trim 'v' from 'v1.22.1' because semver parsing don't like it
+		o.KubeletVersion = strings.TrimPrefix(version, "v")
+		return true, nil
+	})
+	if err != nil || len(o.KubeletVersion) == 0 {
+		klog.Warningf("unable to get kubelet version for node %q: %v", o.NodeName, err)
+	} else {
+		klog.Infof("Got kubelet version %s on target node %s", o.KubeletVersion, o.NodeName)
+	}
+
 	recorder := events.NewRecorder(o.KubeClient.CoreV1().Events(o.Namespace), "static-pod-installer", eventTarget)
 	if err := o.copyContent(ctx); err != nil {
 		recorder.Warningf("StaticPodInstallerFailed", "Installing revision %s: %v", o.Revision, err)
@@ -397,6 +423,16 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 	return nil
 }
 
+func (o *InstallOptions) installerPodNeedUUID() bool {
+	kubeletVersion, err := semver.Make(o.KubeletVersion)
+	if err != nil {
+		klog.Warningf("Failed to parse kubelet version %q to semver: %v (we will not generate pod UID)", err)
+		return false
+	}
+	// if we run kubelet older than 4.9, installer pods require UID generation
+	return kubeletVersion.LT(semver.MustParse("1.22.0"))
+}
+
 func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resourceDir string) error {
 	// the kubelet has a bug that prevents graceful termination from working on static pods with the same name, filename
 	// and uuid.  By setting the pod UID we can work around the kubelet bug and get our graceful termination honored.
@@ -405,7 +441,14 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 	if err != nil {
 		return err
 	}
-	pod.UID = uuid.NewUUID()
+
+	//  If the kubelet version is >=4.9 (1.22), the installer pod UID does not need to be set in the file.
+	if o.installerPodNeedUUID() {
+		pod.UID = uuid.NewUUID()
+	} else {
+		pod.UID = ""
+	}
+
 	for _, fn := range o.PodMutationFns {
 		klog.V(2).Infof("Customizing static pod ...")
 		pod = pod.DeepCopy()

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -246,7 +246,7 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 		}
 	}
 
-	_, _, err = v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cnd))
+	_, _, err = v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cnd))
 	if err != nil {
 		errors = append(errors, err)
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
@@ -63,7 +63,7 @@ func (c *UnsupportedConfigOverridesController) sync(ctx context.Context, syncCtx
 		}
 	}
 
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 	return nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -1,6 +1,7 @@
 package v1helpers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -115,7 +116,7 @@ func IsOperatorConditionPresentAndEqual(conditions []operatorv1.OperatorConditio
 type UpdateOperatorSpecFunc func(spec *operatorv1.OperatorSpec) error
 
 // UpdateSpec applies the update funcs to the oldStatus and tries to update via the client.
-func UpdateSpec(client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*operatorv1.OperatorSpec, bool, error) {
+func UpdateSpec(ctx context.Context, client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*operatorv1.OperatorSpec, bool, error) {
 	updated := false
 	var operatorSpec *operatorv1.OperatorSpec
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -135,7 +136,7 @@ func UpdateSpec(client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*
 			return nil
 		}
 
-		operatorSpec, _, err = client.UpdateOperatorSpec(resourceVersion, newSpec)
+		operatorSpec, _, err = client.UpdateOperatorSpec(ctx, resourceVersion, newSpec)
 		updated = err == nil
 		return err
 	})
@@ -155,7 +156,7 @@ func UpdateObservedConfigFn(config map[string]interface{}) UpdateOperatorSpecFun
 type UpdateStatusFunc func(status *operatorv1.OperatorStatus) error
 
 // UpdateStatus applies the update funcs to the oldStatus and tries to update via the client.
-func UpdateStatus(client OperatorClient, updateFuncs ...UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error) {
+func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error) {
 	updated := false
 	var updatedOperatorStatus *operatorv1.OperatorStatus
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -177,7 +178,7 @@ func UpdateStatus(client OperatorClient, updateFuncs ...UpdateStatusFunc) (*oper
 			return nil
 		}
 
-		updatedOperatorStatus, err = client.UpdateOperatorStatus(resourceVersion, newStatus)
+		updatedOperatorStatus, err = client.UpdateOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
 		return err
 	})
@@ -197,7 +198,7 @@ func UpdateConditionFn(cond operatorv1.OperatorCondition) UpdateStatusFunc {
 type UpdateStaticPodStatusFunc func(status *operatorv1.StaticPodOperatorStatus) error
 
 // UpdateStaticPodStatus applies the update funcs to the oldStatus abd tries to update via the client.
-func UpdateStaticPodStatus(client StaticPodOperatorClient, updateFuncs ...UpdateStaticPodStatusFunc) (*operatorv1.StaticPodOperatorStatus, bool, error) {
+func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, updateFuncs ...UpdateStaticPodStatusFunc) (*operatorv1.StaticPodOperatorStatus, bool, error) {
 	updated := false
 	var updatedOperatorStatus *operatorv1.StaticPodOperatorStatus
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -219,7 +220,7 @@ func UpdateStaticPodStatus(client StaticPodOperatorClient, updateFuncs ...Update
 			return nil
 		}
 
-		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(resourceVersion, newStatus)
+		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
 		return err
 	})
@@ -238,10 +239,10 @@ func UpdateStaticPodConditionFn(cond operatorv1.OperatorCondition) UpdateStaticP
 // EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
 // The finalizer name is computed from the controller name and operator name ($OPERATOR_NAME or os.Args[0])
 // It re-tries on conflicts.
-func EnsureFinalizer(client OperatorClientWithFinalizers, controllerName string) error {
+func EnsureFinalizer(ctx context.Context, client OperatorClientWithFinalizers, controllerName string) error {
 	finalizer := getFinalizerName(controllerName)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return client.EnsureFinalizer(finalizer)
+		return client.EnsureFinalizer(ctx, finalizer)
 	})
 	return err
 }
@@ -249,10 +250,10 @@ func EnsureFinalizer(client OperatorClientWithFinalizers, controllerName string)
 // RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
 // The finalizer name is computed from the controller name and operator name ($OPERATOR_NAME or os.Args[0])
 // It re-tries on conflicts.
-func RemoveFinalizer(client OperatorClientWithFinalizers, controllerName string) error {
+func RemoveFinalizer(ctx context.Context, client OperatorClientWithFinalizers, controllerName string) error {
 	finalizer := getFinalizerName(controllerName)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return client.RemoveFinalizer(finalizer)
+		return client.RemoveFinalizer(ctx, finalizer)
 	})
 	return err
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/interfaces.go
@@ -1,6 +1,8 @@
 package v1helpers
 
 import (
+	"context"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -13,9 +15,9 @@ type OperatorClient interface {
 	// GetOperatorState returns the operator spec, status and the resource version, potentially from a lister.
 	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
 	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource version.
-	UpdateOperatorSpec(oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
+	UpdateOperatorSpec(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
 	// UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
-	UpdateOperatorStatus(oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
+	UpdateOperatorStatus(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
 }
 
 type StaticPodOperatorClient interface {
@@ -25,17 +27,17 @@ type StaticPodOperatorClient interface {
 	GetStaticPodOperatorState() (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
 	// GetStaticPodOperatorStateWithQuorum return the static pod operator spec, status and resource version
 	// directly from a server read.
-	GetStaticPodOperatorStateWithQuorum() (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
+	GetStaticPodOperatorStateWithQuorum(ctx context.Context) (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
 	// UpdateStaticPodOperatorStatus updates the status, assuming the given resource version.
-	UpdateStaticPodOperatorStatus(resourceVersion string, in *operatorv1.StaticPodOperatorStatus) (out *operatorv1.StaticPodOperatorStatus, err error)
+	UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorStatus) (out *operatorv1.StaticPodOperatorStatus, err error)
 	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
-	UpdateStaticPodOperatorSpec(resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
+	UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
 }
 
 type OperatorClientWithFinalizers interface {
 	OperatorClient
 	// EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
-	EnsureFinalizer(finalizer string) error
+	EnsureFinalizer(ctx context.Context, finalizer string) error
 	// RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
-	RemoveFinalizer(finalizer string) error
+	RemoveFinalizer(ctx context.Context, finalizer string) error
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
@@ -97,11 +97,11 @@ func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1.S
 	return c.fakeStaticPodOperatorSpec, c.fakeStaticPodOperatorStatus, c.resourceVersion, nil
 }
 
-func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
+func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum(ctx context.Context) (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
 	return c.fakeStaticPodOperatorSpec, c.fakeStaticPodOperatorStatus, c.resourceVersion, nil
 }
 
-func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
+func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -119,7 +119,7 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVers
 	return c.fakeStaticPodOperatorStatus, nil
 }
 
-func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
+func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, "", errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -140,10 +140,10 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersio
 func (c *fakeStaticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return &c.fakeStaticPodOperatorSpec.OperatorSpec, &c.fakeStaticPodOperatorStatus.OperatorStatus, c.resourceVersion, nil
 }
-func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(context.Context, string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	panic("not supported")
 }
-func (c *fakeStaticPodOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c *fakeStaticPodOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -227,7 +227,7 @@ func (c *fakeOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *oper
 	return c.fakeOperatorSpec, c.fakeOperatorStatus, c.resourceVersion, nil
 }
 
-func (c *fakeOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c *fakeOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -245,7 +245,7 @@ func (c *fakeOperatorClient) UpdateOperatorStatus(resourceVersion string, status
 	return c.fakeOperatorStatus, nil
 }
 
-func (c *fakeOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
+func (c *fakeOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, c.resourceVersion, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -258,7 +258,7 @@ func (c *fakeOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *op
 	return c.fakeOperatorSpec, c.resourceVersion, nil
 }
 
-func (c *fakeOperatorClient) EnsureFinalizer(finalizer string) error {
+func (c *fakeOperatorClient) EnsureFinalizer(ctx context.Context, finalizer string) error {
 	if c.fakeObjectMeta == nil {
 		c.fakeObjectMeta = &metav1.ObjectMeta{}
 	}
@@ -271,7 +271,7 @@ func (c *fakeOperatorClient) EnsureFinalizer(finalizer string) error {
 	return nil
 }
 
-func (c *fakeOperatorClient) RemoveFinalizer(finalizer string) error {
+func (c *fakeOperatorClient) RemoveFinalizer(ctx context.Context, finalizer string) error {
 	newFinalizers := []string{}
 	for _, f := range c.fakeObjectMeta.Finalizers {
 		if f == finalizer {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -213,7 +213,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20210930103404-8911cacccb05
+# github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
* openshift/library-go@c16cd9c: startup-monitor: reduce the log file size
* openshift/library-go@893d6f9: Support for PowerVS platform
* openshift/library-go@bc596ee: Fixed the incorrect formatting
* openshift/library-go@4a22da6: fix registryclient Context.Copy
* openshift/library-go@a6e4a54: add usercache for group retrieval by a given user
* openshift/library-go@a0d9e63: go mod tidy && go mod vendor
* openshift/library-go@a382271: operator/apiserver/controllerset: add options to WithClusterOperatorStatusController
* openshift/library-go@8e20363: update interface
* openshift/library-go@a467daf: update refs
* openshift/library-go@d85ad9c: go fmt
* openshift/library-go@83fd6d2: auth*: configure OWNERS
* openshift/library-go@2d9e145: pkg/operator/configobserver/etcd: bump owners
* openshift/library-go@2f83abd: OWNERS: add Abu and Lukasz as approver
* openshift/library-go@b59a3e8: pkg/operator/staticpod/controller/installer: remove dead code
* openshift/library-go@72a6fd5: Allow resource deletion based on a certain condition
* openshift/library-go@5558388: installerpod: skip installer pod UID generation when running on newer kubelets