### PR TITLE
update KCM metrics service selector

### DIFF
--- a/bindata/assets/kube-controller-manager/svc.yaml
+++ b/bindata/assets/kube-controller-manager/svc.yaml
@@ -5,8 +5,8 @@ metadata:
   name: kube-controller-manager
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
-    prometheus.io/scrape: "true"
-    prometheus.io/scheme: https
+  labels:
+    prometheus: "kube-controller-manager"
 spec:
   selector:
     kube-controller-manager: "true"

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -75,4 +75,6 @@ spec:
   namespaceSelector:
     matchNames:
     - openshift-kube-controller-manager
-  selector: {}
+  selector:
+    matchLabels:
+      prometheus: kube-controller-manager


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/554 changes need to be added incrementally since it was failing during upgrades (https://github.com/openshift/cluster-kube-controller-manager-operator/pull/574#issuecomment-974535812).

We need to backport this to 4.9 and then pin this version in build-suggestions (https://github.com/openshift/cincinnati-graph-data/pull/1220)