### PR TITLE
Collect kube-system namespace as a related resource to kube-controller-manager operator

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_07_clusteroperator.yaml
@@ -32,6 +32,9 @@ status:
       name: openshift-kube-controller-manager-operator
       resource: namespaces
     - group: ""
+      name: kube-system
+      resource: namespaces
+    - group: ""
       resource: nodes
     - group: "certificates.k8s.io"
       resource: "certificatesigningrequests"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -149,6 +149,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			{Resource: "namespaces", Name: "openshift-config-managed"},
 			{Resource: "namespaces", Name: operatorclient.TargetNamespace},
 			{Resource: "namespaces", Name: "openshift-kube-controller-manager-operator"},
+			{Resource: "namespaces", Name: "kube-system"},
 			// TODO move to a more appropriate operator. One that creates and approves these.
 			{Group: "certificates.k8s.io", Resource: "certificatesigningrequests"},
 			// TODO move to a more appropriate operator. One that creates and manages these.


### PR DESCRIPTION
Add kube-system namespace to relatedobjects

We noticed that the operator is using a configmap for leader election that is not a related resource and thus is not gathered by must-gather. Adding the namespace as a related resource will correct this.