### PR TITLE
pdb: add possibility to silence the PodDisruptionBudgetAtLimit alert

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -28,7 +28,7 @@ spec:
             description: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods.
             runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
           expr: |
-            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy and on (namespace, poddisruptionbudget) kube_poddisruptionbudget_status_expected_pods > 0)
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy and on (namespace, poddisruptionbudget) kube_poddisruptionbudget_status_expected_pods > 0 unless on (namespace, poddisruptionbudget) kube_poddisruptionbudget_labels{label_alerts_openshift_io_pod_disruption_budget_at_limit="disabled"} == 1)
           for: 60m
           labels:
             severity: warning


### PR DESCRIPTION
When the label 'alerts.openshift.io/PodDisruptionBudgetAtLimit:disabled' is present on a pdb the alert won't fire for that resource.

Signed-off-by: Antonio Cardace <acardace@redhat.com>