### PR TITLE
Bug 2045872: allow cluster-policy-controller to fallback to default cert

### DIFF
--- a/bindata/assets/kube-controller-manager/svc.yaml
+++ b/bindata/assets/kube-controller-manager/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   name: kube-controller-manager
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: serving-cert
   labels:
     prometheus: "kube-controller-manager"
 spec:

--- a/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
@@ -5,7 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
   labels:
     app: kube-controller-manager-operator
   name: metrics


### PR DESCRIPTION
- default self-signed certificate is used when service-ca controller is
  lagging or unable to start
- kcm pod will be redeployed and the certificate changed as soon as serving-cert is created by
  service-ca