### PR TITLE
bug 2053148: [release-4.10] update library-go to get rapid installer pod fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20220124143425-d74727069f6f
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd
+	github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7
 	github.com/prometheus/common v0.28.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd h1:ytkKe9YmynqosVwvPHKP8kYcCnp/rz/PI3ps+bixOw4=
-github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
+github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7 h1:GK+rgfQQpjZXCVE0MU/ch+HkImtIN1JXc9aRhH1aDj8=
+github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -64,7 +64,14 @@ func NewGuardController(
 	pdbGetter policyclientv1.PodDisruptionBudgetsGetter,
 	eventRecorder events.Recorder,
 	createConditionalFunc func() (bool, bool, error),
-) factory.Controller {
+) (factory.Controller, error) {
+	if operandPodLabelSelector == nil {
+		return nil, fmt.Errorf("GuardController: missing required operandPodLabelSelector")
+	}
+	if operandPodLabelSelector.Empty() {
+		return nil, fmt.Errorf("GuardController: operandPodLabelSelector cannot be empty")
+	}
+
 	c := &GuardController{
 		targetNamespace:         targetNamespace,
 		operandPodLabelSelector: operandPodLabelSelector,
@@ -83,7 +90,7 @@ func NewGuardController(
 	return factory.New().WithInformers(
 		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 		kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
-	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder)
+	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder), nil
 }
 
 func getInstallerPodImageFromEnv() string {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -6,8 +6,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/blang/semver"
 	"github.com/davecgh/go-spew/spew"
@@ -413,6 +417,10 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 	}
 
+	if err := o.waitForOtherInstallerRevisionsToSettle(ctx); err != nil {
+		return err
+	}
+
 	err = retry.RetryOnConnectionErrors(ctx, func(context.Context) (bool, error) {
 		version, err := o.kubeletVersion(ctx)
 		if err != nil {
@@ -436,6 +444,142 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 
 	recorder.Eventf("StaticPodInstallerCompleted", "Successfully installed revision %s", o.Revision)
 	return nil
+}
+
+func (o *InstallOptions) waitForOtherInstallerRevisionsToSettle(ctx context.Context) error {
+	currRevision64, err := strconv.ParseInt(o.Revision, 10, 32)
+	if err != nil {
+		return fmt.Errorf("bad local revision %v: %w", o.Revision, err)
+	}
+	currRevision := int(currRevision64)
+
+	// at this point we have a list of all the installer pods present on this node we need to check
+	// 1. is there a revision later than us present right now.  If yes, exit.
+	// 2. is there an installer pod present that has not finished running, wait until it is finished.
+	err = wait.PollImmediateWithContext(ctx, 10*time.Second, 60*time.Second, func(ctx context.Context) (done bool, err error) {
+		installerPods, err := o.getInstallerPodsOnThisNode(ctx)
+		if err != nil {
+			return false, nil
+		}
+		if len(installerPods) == 0 {
+			return false, fmt.Errorf("no installer pods found")
+		}
+		latestRevision, err := getRevisionOfPod(installerPods[len(installerPods)-1])
+		if err != nil {
+			return false, err
+		}
+		// if there is an installer pod for a newer revision, this installer pod should quit.
+		if latestRevision > currRevision {
+			return false, fmt.Errorf("more recent revision present on node: thisRevision=%v, moreRecentRevision=%v", currRevision, latestRevision)
+		}
+
+		// if any container is not terminated, we need to wait.  There should only ever be a single installer pod
+		// that could be run
+		for _, pod := range installerPods {
+			// skip this revision
+			podRevision, err := getRevisionOfPod(pod)
+			if err != nil {
+				return false, err
+			}
+
+			// skip our own installer pod.
+			if podRevision == currRevision {
+				continue
+			}
+			// wait until we have at least one container status to check
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return false, nil
+			}
+			for _, container := range pod.Status.ContainerStatuses {
+				// if the container isn't terminated, we need this installer pod to wait until it is.
+				if container.State.Terminated == nil {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// once there are no other running revisions, wait Xs.
+	// In an extreme case, this can be grace period seconds+1.  Trying 30s to start. Etcd has been the worst off since
+	// it requires 2 out 3 to be functioning.
+	time.Sleep(30 * time.Second)
+
+	installerPods, err := o.getInstallerPodsOnThisNode(ctx)
+	if err != nil {
+		return err
+	}
+	// if there are no installer pods, it means this pod was removed somehow.  no action should be taken.
+	if len(installerPods) == 0 {
+		return fmt.Errorf("no installer pods found")
+	}
+	latestRevision, err := getRevisionOfPod(installerPods[len(installerPods)-1])
+	if err != nil {
+		return err
+	}
+	// if there is an installer pod for a newer revision, this installer pod should quit.
+	if latestRevision > currRevision {
+		return fmt.Errorf("more recent revision present on node: thisRevision=%v, moreRecentRevision=%v", currRevision, latestRevision)
+	}
+
+	return nil
+}
+
+func (o *InstallOptions) getInstallerPodsOnThisNode(ctx context.Context) ([]*corev1.Pod, error) {
+	podList, err := o.KubeClient.CoreV1().Pods(o.Namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=installer"})
+	if err != nil {
+		return nil, err
+	}
+	installerPodsOnThisNode := []*corev1.Pod{}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !strings.HasPrefix(pod.Name, "installer-") {
+			continue
+		}
+		if pod.Spec.NodeName != o.NodeName {
+			continue
+		}
+		installerPodsOnThisNode = append(installerPodsOnThisNode, pod)
+	}
+	sort.Sort(byRevision(installerPodsOnThisNode))
+
+	return installerPodsOnThisNode, nil
+}
+
+type byRevision []*corev1.Pod
+
+func (s byRevision) Len() int {
+	return len(s)
+}
+func (s byRevision) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s byRevision) Less(i, j int) bool {
+	jRevision, err := getRevisionOfPod(s[j])
+	if err != nil {
+		return true
+	}
+	iRevision, err := getRevisionOfPod(s[i])
+	if err != nil {
+		return false
+	}
+	return iRevision < jRevision
+}
+
+func getRevisionOfPod(pod *corev1.Pod) (int, error) {
+	tokens := strings.Split(pod.Name, "-")
+	if len(tokens) < 2 {
+		return -1, fmt.Errorf("missing revision: %v", pod.Name)
+	}
+	revision, err := strconv.ParseInt(tokens[1], 10, 32)
+	if err != nil {
+		return -1, fmt.Errorf("bad revision for %v: %w", pod.Name, err)
+	}
+	return int(revision), nil
 }
 
 func (o *InstallOptions) installerPodNeedUUID() bool {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,7 +254,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd
+# github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
picking up openshift/library-go#1302

pick of https://github.com/openshift/cluster-kube-controller-manager-operator/pull/597 in 4.10