### PR TITLE
Bug 2049907: allow cluster-policy-controller to fallback to default cert

### DIFF
--- a/bindata/assets/kube-controller-manager/svc.yaml
+++ b/bindata/assets/kube-controller-manager/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   name: kube-controller-manager
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
 spec:

--- a/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_02_service.yaml
@@ -5,7 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert
   labels:
     app: kube-controller-manager-operator
   name: metrics

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -23,6 +23,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
 
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
@@ -42,6 +43,10 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/bindata"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/version"
+)
+
+const (
+	ServingCertSecretAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
 type TargetConfigController struct {
@@ -324,17 +329,47 @@ func manageKubeControllerManagerConfig(ctx context.Context, client corev1client.
 	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
 }
 
-func manageClusterPolicyControllerConfig(ctx context.Context, client corev1client.ConfigMapsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
+func manageClusterPolicyControllerConfig(ctx context.Context, client corev1client.CoreV1Interface, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(bindata.MustAsset("assets/kube-controller-manager/cluster-policy-controller-cm.yaml"))
 	defaultConfig := bindata.MustAsset("assets/config/default-cluster-policy-controller-config.yaml")
+	kcmService := resourceread.ReadServiceV1OrDie(bindata.MustAsset("assets/kube-controller-manager/svc.yaml"))
+	configYamls := [][]byte{
+		defaultConfig,
+		operatorSpec.ObservedConfig.Raw,
+	}
+
+	servingCertName := ""
+	if kcmService.Annotations != nil {
+		servingCertName = kcmService.Annotations[ServingCertSecretAnnotation]
+	}
+
+	if len(servingCertName) == 0 {
+		return nil, false, fmt.Errorf("missing %s annotation in %s/%s service", kcmService.Namespace, kcmService.Name, ServingCertSecretAnnotation)
+	}
+
+	_, err := client.Secrets(operatorclient.TargetNamespace).Get(ctx, servingCertName, metav1.GetOptions{})
+
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, false, err
+	} else if apierrors.IsNotFound(err) {
+		// Should only apply when starting the cluster so cluster-policy-controller is able to annotate openshift-service-ca namespace.
+		// Then service-ca controller should start and create serving-cert.
+		// We will put the serving-cert into the config as soon as it appears which will then trigger new installer.
+
+		klog.V(1).Info("serving-cert not found: falling back to default self-signed certificate in cluster-policy-controller")
+		configOverride := "{\"servingInfo\": { \"certFile\": \"\", \"keyFile\": \"\"} }"
+		// this will trigger defaulting here https://github.com/openshift/library-go/blob/512c504748ee57ea97f6014e8fe3085c8dd5b144/pkg/controller/controllercmd/cmd.go#L204
+		configYamls = append(configYamls, []byte(configOverride))
+	}
+
+	configYamls = append(configYamls, operatorSpec.UnsupportedConfigOverrides.Raw)
+
 	requiredConfigMap, _, err := resourcemerge.MergePrunedConfigMap(
 		&openshiftcontrolplanev1.OpenShiftControllerManagerConfig{},
 		configMap,
 		"config.yaml",
 		nil,
-		defaultConfig,
-		operatorSpec.ObservedConfig.Raw,
-		operatorSpec.UnsupportedConfigOverrides.Raw)
+		configYamls...)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
- default self-signed certificate is used when service-ca controller is
  lagging or unable to start
- kcm pod will be redeployed and the certificate changed as soon as serving-cert is created by
  service-ca