### PR TITLE
introduce a reverse proxy to KCM and CPC in order to enable CPC metrics 

### DIFF
--- a/bindata/assets/config/default-cluster-policy-controller-config.yaml
+++ b/bindata/assets/config/default-cluster-policy-controller-config.yaml
@@ -4,5 +4,5 @@ servingInfo:
   bindAddress: 0.0.0.0:10357
   bindNetwork: tcp
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key
+  certFile: /etc/kubernetes/static-pod-resources/secrets/cpc-localhost-serving-cert/tls.crt
+  keyFile: /etc/kubernetes/static-pod-resources/secrets/cpc-localhost-serving-cert/tls.key

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -29,7 +29,7 @@ extendedArguments:
   cluster-signing-duration:
   - "720h"
   secure-port:
-  - "10257"
+  - "10358"
   cert-dir:
   - "/var/run/kubernetes"
   root-ca-file:

--- a/bindata/assets/kube-controller-manager/pod.yaml
+++ b/bindata/assets/kube-controller-manager/pod.yaml
@@ -19,7 +19,7 @@ spec:
     command: ["/bin/bash", "-euxo", "pipefail", "-c"]
     args:
         - |
-          timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10257 \))" ]; do sleep 1; done'
+          timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10358 \))" ]; do sleep 1; done'
 
           if [ -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
             echo "Copying system trust bundle"
@@ -42,7 +42,7 @@ spec:
         memory: 200Mi
         cpu: 60m
     ports:
-      - containerPort: 10257
+      - containerPort: 10358
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
@@ -51,21 +51,21 @@ spec:
     startupProbe:
       httpGet:
         scheme: HTTPS
-        port: 10257
+        port: 10358
         path: healthz
       initialDelaySeconds: 0
       timeoutSeconds: 3
     livenessProbe:
       httpGet:
         scheme: HTTPS
-        port: 10257
+        port: 10358
         path: healthz
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
       httpGet:
         scheme: HTTPS
-        port: 10257
+        port: 10358
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
@@ -173,6 +173,52 @@ spec:
         name: resource-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
+  - name: kcm-cpc-reverse-proxy
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["/bin/bash", "-euxo", "pipefail", "-c"]
+    args:
+      - |
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10257 \))" ]; do sleep 1; done'
+        
+        exec cluster-kube-controller-manager-operator reverse-proxy \
+          --listen=0.0.0.0:10257 \
+          --kcm-port=10358 \
+          --cpc-port=10357 \
+          --cpc-url-path-prefix=/cluster-policy-controller
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 5m
+    ports:
+      - containerPort: 10257
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
+    startupProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 0
+      timeoutSeconds: 3
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 45
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 10257
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/bindata/assets/kube-controller-manager/svc.yaml
+++ b/bindata/assets/kube-controller-manager/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: openshift-kube-controller-manager
   name: kube-controller-manager
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: kcm-cpc-reverse-proxy-serving-cert
   labels:
     prometheus: "kube-controller-manager"
 spec:

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,6 +1,8 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeControllerManagerConfig
 extendedArguments:
+  secure-port:
+  - "10257"
   root-ca-file:
   - "/etc/kubernetes/secrets/kube-apiserver-complete-server-ca-bundle.crt"
   service-account-private-key-file:

--- a/cmd/cluster-kube-controller-manager-operator/main.go
+++ b/cmd/cluster-kube-controller-manager-operator/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/recoverycontroller"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/render"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/resourcegraph"
+	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/cmd/reverseproxy"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator"
 )
 
@@ -42,6 +43,7 @@ func NewSSCSCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
 	cmd.AddCommand(recoverycontroller.NewCertRecoveryControllerCommand(ctx))
+	cmd.AddCommand(reverseproxy.NewReverseProxyCommand())
 
 	return cmd
 }

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -78,3 +78,46 @@ spec:
   selector:
     matchLabels:
       prometheus: kube-controller-manager
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kube-controller-manager
+  name: cluster-policy-controller
+  namespace: openshift-kube-controller-manager
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|request|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: rest_client_request_latency_seconds_(bucket|count|sum)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)
+          sourceLabels:
+            - __name__
+      port: https
+      scheme: https
+      path: /cluster-policy-controller/metrics
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: kube-controller-manager.openshift-kube-controller-manager.svc
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+  namespaceSelector:
+    matchNames:
+      - openshift-kube-controller-manager
+  selector:
+    matchLabels:
+      prometheus: kube-controller-manager

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -65,7 +65,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: rest_client_request_latency_seconds_(bucket|count|sum)
+      regex: rest_client_request_duration_seconds_(bucket|count|sum)
       sourceLabels:
       - __name__
     - action: drop
@@ -114,7 +114,7 @@ spec:
           sourceLabels:
             - __name__
         - action: drop
-          regex: rest_client_request_latency_seconds_(bucket|count|sum)
+          regex: rest_client_request_duration_seconds_(bucket|count|sum)
           sourceLabels:
             - __name__
         - action: drop

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -52,6 +52,13 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
+    relabelings:
+      - action: replace
+        targetLabel: container
+        replacement: kube-controller-manager
+      - action: replace
+        targetLabel: job
+        replacement: kube-controller-manager
     metricRelabelings:
     - action: drop
       regex: etcd_(debugging|disk|request|server).*
@@ -94,6 +101,13 @@ spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 30s
+      relabelings:
+        - action: replace
+          targetLabel: container
+          replacement: cluster-policy-controller
+        - action: replace
+          targetLabel: job
+          replacement: cluster-policy-controller
       metricRelabelings:
         - action: drop
           regex: etcd_(debugging|disk|request|server).*

--- a/pkg/cmd/reverseproxy/cmd.go
+++ b/pkg/cmd/reverseproxy/cmd.go
@@ -1,0 +1,227 @@
+package reverseproxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+// reverseProxyOpts holds values to run the proxy.
+type reverseProxyOpts struct {
+	bindAddress string
+	certFile    string
+	keyFile     string
+
+	kcmPort         string
+	kcmCABundleFile string
+
+	cpcPort         string
+	cpcCABundleFile string
+	cpcPathPrefix   string
+}
+
+const kcmPathPrefix = "/"
+
+// NewReverseProxyCommand creates a render command.
+func NewReverseProxyCommand() *cobra.Command {
+	proxyOpts := &reverseProxyOpts{}
+	cmd := &cobra.Command{
+		Use:   "reverse-proxy",
+		Short: "Start Reverse Proxy for Kube Controller Manager and Cluster Policy Controller to be able to serve metrics on the same port\"",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := proxyOpts.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+			if err := proxyOpts.Run(); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	proxyOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (r *reverseProxyOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&r.bindAddress, "listen", r.bindAddress, "The ip:port to serve on.")
+	fs.StringVar(&r.certFile, "tls-cert-file", r.certFile, "serving certificate file (defaults to a generated cert)")
+	fs.StringVar(&r.keyFile, "tls-private-key-file", r.keyFile, "serving certificate key file (defaults to a generated cert)")
+
+	fs.StringVar(&r.kcmPort, "kcm-port", r.kcmPort, "Kube Controller Manager port")
+	fs.StringVar(&r.kcmCABundleFile, "kcm-cabundle-file", r.kcmCABundleFile, "Kube Controller Manager CA bundle certificates")
+
+	fs.StringVar(&r.cpcPort, "cpc-port", r.cpcPort, "Cluster Policy Controller port")
+	fs.StringVar(&r.cpcCABundleFile, "cpc-cabundle-file", r.cpcCABundleFile, "Cluster Policy Controller CA bundle certificates")
+	fs.StringVar(&r.cpcPathPrefix, "cpc-url-path-prefix", r.cpcPathPrefix, "URL path prefix for Cluster Policy Controller")
+}
+
+// Validate verifies the inputs.
+func (r *reverseProxyOpts) Validate() error {
+	if len(r.bindAddress) == 0 {
+		return errors.New("missing required flag: --listen")
+	}
+
+	hasCertFile, hasKeyFile := len(r.certFile) == 0, len(r.keyFile) == 0
+	if hasCertFile != hasKeyFile {
+		return errors.New("incorrect flags: eiter both --tls-cert-file and --tls-private-key-file are required for setting serving cert, or none to auto-generate the serving cert")
+	}
+
+	if len(r.kcmPort) == 0 {
+		return errors.New("missing required flag: --kcm-port")
+	}
+	if len(r.kcmCABundleFile) == 0 {
+		return errors.New("missing required flag: --kcm-cabundle-file")
+	}
+
+	if len(r.cpcPort) == 0 {
+		return errors.New("missing required flag: --cpc-port")
+	}
+	if len(r.cpcCABundleFile) == 0 {
+		return errors.New("missing required flag: --cpc-cabundle-file")
+	}
+	if len(r.cpcPathPrefix) == 0 {
+		return errors.New("missing required flag: --cpc-url-path-prefix")
+	}
+	return nil
+}
+
+// Run contains the logic of the proxy command.
+func (r *reverseProxyOpts) Run() error {
+	if len(r.certFile) == 0 || len(r.keyFile) == 0 {
+		err := r.generateSelfSignedCert()
+		if err != nil {
+			return err
+		}
+	}
+
+	kcmURL, err := url.Parse("https://" + net.JoinHostPort("127.0.0.1", r.kcmPort))
+	if err != nil {
+		return err
+	}
+	cpcURL, err := url.Parse("https://" + net.JoinHostPort("127.0.0.1", r.cpcPort))
+	if err != nil {
+		return err
+	}
+
+	kcmProxy, err := newReverseProxy(kcmURL, r.kcmCABundleFile, kcmPathPrefix)
+	if err != nil {
+		return err
+	}
+	kcmHandler := reverseProxyHandler(kcmProxy)
+
+	cpcProxy, err := newReverseProxy(cpcURL, r.cpcCABundleFile, r.cpcPathPrefix)
+	if err != nil {
+		return err
+	}
+	cpcHandler := reverseProxyHandler(cpcProxy)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(kcmPathPrefix, kcmHandler)
+	mux.HandleFunc(r.cpcPathPrefix, cpcHandler)
+	mux.HandleFunc(r.cpcPathPrefix+"/", cpcHandler)
+
+	srv := &http.Server{Addr: r.bindAddress, Handler: mux}
+	defer srv.Close()
+
+	klog.Infof("Listening on %v", r.bindAddress)
+	return srv.ListenAndServeTLS(r.certFile, r.keyFile)
+}
+
+func (r *reverseProxyOpts) generateSelfSignedCert() error {
+	klog.Warningf("Using insecure, self-signed certificates")
+
+	temporaryCertDir, err := ioutil.TempDir("", "reverse-proxy-serving-cert-")
+	if err != nil {
+		return err
+	}
+	signerName := fmt.Sprintf("reverse-proxy-signer@%d", time.Now().Unix())
+	ca, err := crypto.MakeSelfSignedCA(
+		filepath.Join(temporaryCertDir, "serving-signer.crt"),
+		filepath.Join(temporaryCertDir, "serving-signer.key"),
+		filepath.Join(temporaryCertDir, "serving-signer.serial"),
+		signerName,
+		0,
+	)
+	if err != nil {
+		return err
+	}
+
+	r.certFile = filepath.Join(temporaryCertDir, "tls.crt")
+	r.keyFile = filepath.Join(temporaryCertDir, "tls.key")
+	// nothing can trust this, so we don't really care about hostnames
+	servingCert, err := ca.MakeServerCert(sets.NewString("localhost", "127.0.0.1"), 30)
+	if err != nil {
+		return err
+	}
+	if err := servingCert.WriteCertConfigFile(r.certFile, r.keyFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newReverseProxy(target *url.URL, caBundleFile string, pathPrefix string) (*httputil.ReverseProxy, error) {
+	if target.Path != "" || target.RawPath != "" || target.RawQuery != "" {
+		return nil, errors.New("ReverseProxy Director only supports URL without a path")
+	}
+	proxy := &httputil.ReverseProxy{}
+
+	rootCAs := x509.NewCertPool()
+
+	caCert, err := ioutil.ReadFile(caBundleFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if !rootCAs.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("could not append caCert to root CAs")
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs: rootCAs,
+	}
+	proxy.Transport = transport
+
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		if len(pathPrefix) != 0 && pathPrefix != "/" {
+			req.URL.Path = strings.TrimPrefix(req.URL.Path, pathPrefix)
+			if len(req.URL.RawPath) != 0 {
+				req.URL.RawPath = strings.TrimPrefix(req.URL.EscapedPath(), pathPrefix)
+			}
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+
+	return proxy, nil
+}
+
+func reverseProxyHandler(proxy *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		proxy.ServeHTTP(w, r)
+	}
+}

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -118,7 +118,86 @@ func newCertRotationController(
 		operatorClient,
 		eventRecorder,
 	)
+	ret.certRotators = append(ret.certRotators, certRotator)
 
+	certRotator = certrotation.NewCertRotationController(
+		"KubeControllerManagerLocalhostServing",
+		certrotation.RotatedSigningCASecret{
+			Namespace:              operatorclient.OperatorNamespace,
+			Name:                   "kcm-localhost-serving-signer",
+			Validity:               10 * 365 * rotationDay,
+			Refresh:                8 * 365 * rotationDay, // this means we effectively do not rotate
+			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+			Client:                 secretsGetter,
+			EventRecorder:          eventRecorder,
+		},
+		certrotation.CABundleConfigMap{
+			Namespace:     operatorclient.TargetNamespace,
+			Name:          "kcm-localhost-serving-ca",
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
+			Client:        configMapsGetter,
+			EventRecorder: eventRecorder,
+		},
+		certrotation.RotatedSelfSignedCertKeySecret{
+			Namespace:              operatorclient.TargetNamespace,
+			Name:                   "kcm-localhost-serving-cert",
+			Validity:               850 * rotationDay, // 28 months - kcm-cpc-reverse-proxy-serving-cert has 26 months
+			Refresh:                425 * rotationDay, // 14 months - kcm-cpc-reverse-proxy-serving-cert has 13 months
+			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+			CertCreator: &certrotation.ServingRotation{
+				Hostnames: func() []string { return []string{"localhost", "127.0.0.1"} },
+			},
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
+			Client:        secretsGetter,
+			EventRecorder: eventRecorder,
+		},
+		operatorClient,
+		eventRecorder,
+	)
+	ret.certRotators = append(ret.certRotators, certRotator)
+
+	certRotator = certrotation.NewCertRotationController(
+		"ClusterPolicyControllerLocalhostServing",
+		certrotation.RotatedSigningCASecret{
+			Namespace:              operatorclient.OperatorNamespace,
+			Name:                   "cpc-localhost-serving-signer",
+			Validity:               10 * 365 * rotationDay,
+			Refresh:                8 * 365 * rotationDay, // this means we effectively do not rotate
+			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+			Client:                 secretsGetter,
+			EventRecorder:          eventRecorder,
+		},
+		certrotation.CABundleConfigMap{
+			Namespace:     operatorclient.TargetNamespace,
+			Name:          "cpc-localhost-serving-ca",
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
+			Client:        configMapsGetter,
+			EventRecorder: eventRecorder,
+		},
+		certrotation.RotatedSelfSignedCertKeySecret{
+			Namespace:              operatorclient.TargetNamespace,
+			Name:                   "cpc-localhost-serving-cert",
+			Validity:               850 * rotationDay, // 28 months - kcm-cpc-reverse-proxy-serving-cert has 26 months
+			Refresh:                425 * rotationDay, // 14 months - kcm-cpc-reverse-proxy-serving-cert has 13 months
+			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+			CertCreator: &certrotation.ServingRotation{
+				Hostnames: func() []string { return []string{"localhost", "127.0.0.1"} },
+			},
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
+			Client:        secretsGetter,
+			EventRecorder: eventRecorder,
+		},
+		operatorClient,
+		eventRecorder,
+	)
 	ret.certRotators = append(ret.certRotators, certRotator)
 
 	return ret, nil

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -238,14 +238,22 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "serviceaccount-ca"},
 	{Name: "service-ca"},
 	{Name: "recycler-config"},
+
+	// created by certrotation controller
+	{Name: "kcm-localhost-serving-ca"},
+	{Name: "cpc-localhost-serving-ca"},
 }
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
 var deploymentSecrets = []revision.RevisionResource{
 	{Name: "service-account-private-key"},
 
+	// created by certrotation controller
+	{Name: "kcm-localhost-serving-cert"},
+	{Name: "cpc-localhost-serving-cert"},
+
 	// this cert is created by the service-ca controller, which doesn't come up until after we are available. this piece of config must be optional.
-	{Name: "serving-cert", Optional: true},
+	{Name: "kcm-cpc-reverse-proxy-serving-cert", Optional: true},
 
 	// this needs to be revisioned as certsyncer's kubeconfig isn't wired to be live reloaded, nor will be autorecovery
 	{Name: "localhost-recovery-client-token"},


### PR DESCRIPTION
- KCM is now serving on port 10358, so the proxy can take KCM's former port 10257 which is opened on nodes and can be used by prometheus for metrics

- serving-cert is used by the proxy and renamed to kcm-cpc-reverse-proxy-serving-cert
- introduce new localhost certificates
  - cpc-localhost-serving-cert
  - kcm-localhost-serving-cert