### PR TITLE
e2e: Fix test pod disruption budget at limit alert

### DIFF
--- a/test/e2e-preferred-host/kcm_preferred_host_kas_test.go
+++ b/test/e2e-preferred-host/kcm_preferred_host_kas_test.go
@@ -16,14 +16,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	watchtools "k8s.io/client-go/tools/watch"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
@@ -42,11 +36,6 @@ var (
 	// KCMs are considered to not converged
 	waitForKCMRevisionPollInterval = 30 * time.Second
 	waitForKCMRevisionTimeout      = 7 * time.Minute
-
-	// serviceAccountProvisionTimeout is how long to wait for a service account to be provisioned.
-	// service accounts are provisioned after namespace creation
-	// a service account is required to support pod creation in a namespace as part of admission control
-	serviceAccountProvisionTimeout = 2 * time.Minute
 
 	nsCreationPollInterval = 2 * time.Second
 )
@@ -90,7 +79,7 @@ func TestKCMTalksOverPreferredHostToKAS(t *testing.T) {
 	t.Log("creating a namespace and waiting for a default sa to be populated")
 	testNs, err := createTestingNS(t, "kcm-preferred-host", kubeClient)
 	require.NoError(t, err)
-	err = waitForServiceAccountInNamespace(kubeClient, testNs.Name, "default")
+	err = test.WaitForServiceAccountInNamespace(kubeClient, testNs.Name, "default")
 	require.NoError(t, err)
 }
 
@@ -154,38 +143,4 @@ func createTestingNS(t *testing.T, baseName string, c clientset.Interface) (*v1.
 	}
 
 	return got, nil
-}
-
-// note this method has been copied from k/k repo
-func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountName string) error {
-	fieldSelector := fields.OneTermEqualSelector("metadata.name", serviceAccountName).String()
-	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
-			options.FieldSelector = fieldSelector
-			return c.CoreV1().ServiceAccounts(ns).List(context.TODO(), options)
-		},
-		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
-			options.FieldSelector = fieldSelector
-			return c.CoreV1().ServiceAccounts(ns).Watch(context.TODO(), options)
-		},
-	}
-	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), serviceAccountProvisionTimeout)
-	defer cancel()
-	_, err := watchtools.UntilWithSync(ctx, lw, &v1.ServiceAccount{}, nil, serviceAccountHasSecrets)
-	return err
-}
-
-// serviceAccountHasSecrets returns true if the service account has at least one secret,
-// false if it does not, or an error.
-// note this method has been copied from k/k repo
-func serviceAccountHasSecrets(event watch.Event) (bool, error) {
-	switch event.Type {
-	case watch.Deleted:
-		return false, apierrors.NewNotFound(schema.GroupResource{Resource: "serviceaccounts"}, "")
-	}
-	switch t := event.Object.(type) {
-	case *v1.ServiceAccount:
-		return len(t.Secrets) > 0, nil
-	}
-	return false, nil
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/kubernetes"
-	policyclientv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	policyclientv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
 
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
@@ -60,7 +60,7 @@ func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	policyClient, err := policyclientv1beta1.NewForConfig(kubeConfig)
+	policyClient, err := policyclientv1.NewForConfig(kubeConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,13 +286,13 @@ func TestKCMRecovery(t *testing.T) {
 	}
 }
 
-func pdbCreate(client *policyclientv1beta1.PolicyV1beta1Client, name string, labels map[string]string) error {
+func pdbCreate(client *policyclientv1.PolicyV1Client, name string, labels map[string]string) error {
 	minAvailable := intstr.FromInt(1)
-	pdb := &policyv1beta1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector:     &metav1.LabelSelector{MatchLabels: labels},
 		},

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -79,6 +79,10 @@ func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
 		t.Fatalf("could not create test namespace: %v", err)
 	}
 	defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	err = test.WaitForServiceAccountInNamespace(kubeClient, name, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	labels := map[string]string{"app": "pdbtest"}
 	err = pdbCreate(policyClient, name, labels)

--- a/test/library/namespace.go
+++ b/test/library/namespace.go
@@ -1,0 +1,59 @@
+package library
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+var (
+	// serviceAccountProvisionTimeout is how long to wait for a service account to be provisioned.
+	// service accounts are provisioned after namespace creation
+	// a service account is required to support pod creation in a namespace as part of admission control
+	serviceAccountProvisionTimeout = 2 * time.Minute
+)
+
+// WaitForServiceAccountInNamespace waits for a creation of a service account in a new namespace
+// note this method has been copied from k/k repo
+func WaitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountName string) error {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", serviceAccountName).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
+			options.FieldSelector = fieldSelector
+			return c.CoreV1().ServiceAccounts(ns).List(context.TODO(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
+			options.FieldSelector = fieldSelector
+			return c.CoreV1().ServiceAccounts(ns).Watch(context.TODO(), options)
+		},
+	}
+	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), serviceAccountProvisionTimeout)
+	defer cancel()
+	_, err := watchtools.UntilWithSync(ctx, lw, &v1.ServiceAccount{}, nil, serviceAccountHasSecrets)
+	return err
+}
+
+// serviceAccountHasSecrets returns true if the service account has at least one secret,
+// false if it does not, or an error.
+// note this method has been copied from k/k repo
+func serviceAccountHasSecrets(event watch.Event) (bool, error) {
+	switch event.Type {
+	case watch.Deleted:
+		return false, apierrors.NewNotFound(schema.GroupResource{Resource: "serviceaccounts"}, "")
+	}
+	switch t := event.Object.(type) {
+	case *v1.ServiceAccount:
+		return len(t.Secrets) > 0, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
in 5% [cases](https://search.ci.openshift.org/?search=.*TestPodDisruptionBudgetAtLimitAlert.*&maxAge=336h&context=1&type=bug%2Bjunit&name=e2e-aws-operator&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) there is a SA missing in the test namespace:

```
 operator_test.go:103: pods "pdbtest-9t6n7" is forbidden: error looking up service account pdbtest-9t6n7/default: serviceaccount "default" not found
```

I could not reproduce this at my cluster, but this should fix it.
