### PR TITLE
Bug 2086519: bindata/../namespace-openshift-infra: label namespace as privileged

### DIFF
--- a/bindata/bootkube/manifests/0000_00_namespace-openshift-infra.yaml
+++ b/bindata/bootkube/manifests/0000_00_namespace-openshift-infra.yaml
@@ -4,3 +4,7 @@ metadata:
   annotations:
     workload.openshift.io/allowed: "management"
   name: openshift-infra
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

During an e2e run for https://github.com/openshift/cluster-kube-apiserver-operator/pull/1339 (https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-kube-apiserver-operator/1339/pull-ci-openshift-cluster-kube-apiserver-operator-master-e2e-aws/1526469279988322304): ` [sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted. [Suite:openshift/conformance/parallel] [Suite:k8s] expand_less`:

```
➜  ~ kubectl -n pv-3527 describe pv
Name:            nfs-wwdsn
Labels:          e2e-pv-pool=pv-3527
Annotations:     pv.beta.kubernetes.io/gid: 777
                 pv.kubernetes.io/bound-by-controller: yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:
Status:          Failed
Claim:           pv-3527/pvc-8x79k
Reclaim Policy:  Recycle
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        2Gi
Node Affinity:   <none>
Message:         Recycle failed: unexpected error creating recycler pod:  pods "recycler-for-nfs-wwdsn" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "recycler-container" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "recycler-container" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "vol" uses restricted volume type "nfs"), runAsNonRoot != true (pod or container "recycler-container" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "recycler-container" must not set runAsUser=0), seccompProfile (pod or container "recycler-container" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Source:
    Type:      NFS (an NFS mount that lasts the lifetime of a pod)
    Server:    10.129.2.17
    Path:      /exports
    ReadOnly:  false
Events:
  Type     Reason               Age    From                         Message
  ----     ------               ----   ----                         -------
  Warning  VolumeFailedRecycle  2m35s  persistentvolume-controller  Recycle failed: unexpected error creating recycler pod:  pods "recycler-for-nfs-wwdsn" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "recycler-container" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "recycler-container" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "vol" uses restricted volume type "nfs"), runAsNonRoot != true (pod or container "recycler-container" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "recycler-container" must not set runAsUser=0), seccompProfile (pod or container "recycler-container" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

The recycler pod needs to run as root as per https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/bindata/assets/kube-controller-manager/recycler-cm.yaml#L31.

/cc @soltysh @stlaz 