### PR TITLE
Bug 2053622: PodDisruptionBudgetAtLimit should not alert when no app/pods exist

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -26,7 +26,7 @@ spec:
             summary: The pod disruption budget is preventing further disruption to pods.
             description: The pod disruption budget is at minimum disruptions allowed level. The number of current healthy pods is equal to desired healthy pods.
           expr: |
-            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy)
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy and on (namespace, poddisruptionbudget) kube_poddisruptionbudget_status_expected_pods > 0)
           for: 60m
           labels:
             severity: warning

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,7 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	machineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -20,14 +21,14 @@ import (
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/operatorclient"
-	test "github.com/openshift/cluster-kube-controller-manager-operator/test/library"
+	testlib "github.com/openshift/cluster-kube-controller-manager-operator/test/library"
 	"github.com/openshift/library-go/test/library/metrics"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOperatorNamespace(t *testing.T) {
-	kubeConfig, err := test.NewClientConfigForTest()
+	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,10 +43,9 @@ func TestOperatorNamespace(t *testing.T) {
 	}
 }
 
-// TestPodDisruptionBudgetAtLimitAlert tests that pdb-atlimit alert exists when there is a pdb at limit
-// See https://bugzilla.redhat.com/show_bug.cgi?id=1762888
+// TestPodDisruptionBudgetAtLimitAlert tests that PodDisruptionBudgetAtLimit alert behaves properly
 func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
-	kubeConfig, err := test.NewClientConfigForTest()
+	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,80 +67,118 @@ func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
 
 	ctx := context.Background()
 
-	name := names.SimpleNameGenerator.GenerateName("pdbtest-")
-	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+	tests := []struct {
+		name           string
+		createPod      bool
+		shouldAlert    bool
+		minAvailable   int
+		maxUnavailable int
+	}{
+		// test PodDisruptionBudgetAtLimit alert exists when there is a pdb at limit
+		// See https://bugzilla.redhat.com/show_bug.cgi?id=1762888
+		{
+			name:         "should alert when pdb at limit",
+			createPod:    true,
+			shouldAlert:  true,
+			minAvailable: 1,
 		},
-	},
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Fatalf("could not create test namespace: %v", err)
-	}
-	defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
-	err = test.WaitForServiceAccountInNamespace(kubeClient, name, "default")
-	if err != nil {
-		t.Fatal(err)
+		// test PodDisruptionBudgetAtLimit alert missing when no app exists (currentHealthy and desiredHealthy equal to 0)
+		// See https://bugzilla.redhat.com/show_bug.cgi?id=2053622
+		{
+			name:           "should not alert when pdb at limit but no app pods exist",
+			createPod:      false,
+			shouldAlert:    false,
+			maxUnavailable: 1,
+		},
 	}
 
-	labels := map[string]string{"app": "pdbtest"}
-	err = pdbCreate(policyClient, name, labels)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	// Warning: second test waits for this whole duration
 	testTimeout := time.Second * 120
 
-	err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-		if _, err := policyClient.PodDisruptionBudgets(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pbtest"}); err != nil {
-			return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
-		}
-		return true, nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			name := names.SimpleNameGenerator.GenerateName("pdbtest-")
+			_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			},
+				metav1.CreateOptions{},
+			)
+			if err != nil {
+				t.Fatalf("could not create test namespace: %v", err)
+			}
+			defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+			err = testlib.WaitForServiceAccountInNamespace(kubeClient, name, "default")
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	err = podCreate(kubeClient, name, labels)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var pods *corev1.PodList
-	// Poll to confirm pod is running
-	wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-		pods, err = kubeClient.CoreV1().Pods(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pdbtest"})
-		if err != nil {
-			return false, err
-		}
-		if len(pods.Items) > 0 && pods.Items[0].Status.Phase == corev1.PodRunning {
-			return true, nil
-		}
-		return false, nil
-	})
+			labels := map[string]string{"app": "pdbtest"}
+			err = pdbCreate(policyClient, name, test.minAvailable, test.maxUnavailable, labels)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Now check for alert
-	prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
-	if err != nil {
-		t.Fatalf("error creating route client for prometheus: %v", err)
-	}
-	var response model.Value
-	// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
-	// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
-	// The thanos behavior is to error on partial response.
-	query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
-	err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
-		response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
-		if err != nil {
-			return false, fmt.Errorf("error querying prometheus: %v", err)
-		}
-		if len(response.String()) == 0 {
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		t.Fatalf("error querying prometheus: %v", err)
+			err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
+				if _, err := policyClient.PodDisruptionBudgets(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pbtest"}); err != nil {
+					return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
+				}
+				return true, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.createPod {
+				err = podCreate(kubeClient, name, labels)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var pods *corev1.PodList
+				// Poll to confirm pod is running
+				wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
+					pods, err = kubeClient.CoreV1().Pods(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pdbtest"})
+					if err != nil {
+						return false, err
+					}
+					if len(pods.Items) > 0 && pods.Items[0].Status.Phase == corev1.PodRunning {
+						return true, nil
+					}
+					return false, nil
+				})
+			}
+
+			// Now check for alert
+			prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
+			if err != nil {
+				t.Fatalf("error creating route client for prometheus: %v", err)
+			}
+			var response model.Value
+			// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
+			// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
+			// The thanos behavior is to error on partial response.
+			query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
+			err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
+				response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
+				if err != nil {
+					return false, fmt.Errorf("error querying prometheus: %v", err)
+				}
+				if len(response.String()) == 0 {
+					return false, nil
+				}
+				return true, nil
+			})
+			if test.shouldAlert {
+				if err != nil {
+					t.Fatalf("error querying prometheus: %v", err)
+				}
+			} else {
+				if !errors.Is(err, wait.ErrWaitTimeout) {
+					t.Fatalf("expected timeout err as alert should not be received, got: %v", err)
+				}
+			}
+		})
 	}
 }
 
@@ -168,7 +206,7 @@ func TestTargetConfigController(t *testing.T) {
 		},
 	}
 
-	kubeConfig, err := test.NewClientConfigForTest()
+	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +254,7 @@ func TestResourceSyncController(t *testing.T) {
 		},
 	}
 
-	kubeConfig, err := test.NewClientConfigForTest()
+	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +281,7 @@ func testConfigMapDeletion(kubeClient *kubernetes.Clientset, namespace, config s
 	}
 	err = wait.Poll(time.Second*5, time.Second*120, func() (bool, error) {
 		_, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, config, metav1.GetOptions{})
-		if errors.IsNotFound(err) {
+		if machineryerrors.IsNotFound(err) {
 			return false, nil
 		}
 		if err != nil {
@@ -257,7 +295,7 @@ func testConfigMapDeletion(kubeClient *kubernetes.Clientset, namespace, config s
 func TestKCMRecovery(t *testing.T) {
 	// This is an e2e test to verify that KCM can recover from having its lease configmap deleted
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
-	kubeConfig, err := test.NewClientConfigForTest()
+	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,7 +315,7 @@ func TestKCMRecovery(t *testing.T) {
 	// Check to see that the lease object then gets recreated
 	err = wait.Poll(time.Second*5, time.Second*300, func() (bool, error) {
 		_, err := kubeClient.CoordinationV1().Leases("kube-system").Get(ctx, "kube-controller-manager", metav1.GetOptions{})
-		if errors.IsNotFound(err) {
+		if machineryerrors.IsNotFound(err) {
 			return false, nil
 		}
 		if err != nil {
@@ -290,16 +328,22 @@ func TestKCMRecovery(t *testing.T) {
 	}
 }
 
-func pdbCreate(client *policyclientv1.PolicyV1Client, name string, labels map[string]string) error {
-	minAvailable := intstr.FromInt(1)
+func pdbCreate(client *policyclientv1.PolicyV1Client, name string, minAvailable int, maxUnavailable int, labels map[string]string) error {
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
-			Selector:     &metav1.LabelSelector{MatchLabels: labels},
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
 		},
+	}
+	if minAvailable > 0 {
+		minA := intstr.FromInt(minAvailable)
+		pdb.Spec.MinAvailable = &minA
+	}
+	if maxUnavailable > 0 {
+		maxU := intstr.FromInt(maxUnavailable)
+		pdb.Spec.MaxUnavailable = &maxU
 	}
 	_, err := client.PodDisruptionBudgets(name).Create(context.Background(), pdb, metav1.CreateOptions{})
 	return err
@@ -331,7 +375,7 @@ func podCreate(client *kubernetes.Clientset, name string, labels map[string]stri
 }
 
 func TestLogLevel(t *testing.T) {
-	kubeConfig, err := test.NewClientConfigForTest()
+	kubeConfig, err := testlib.NewClientConfigForTest()
 	require.NoError(t, err)
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
 	require.NoError(t, err)


### PR DESCRIPTION
meaning alert should not fire when currentHealthy == 0 and desiredHealthy == 0

It makes sense to not fire an alert if there is no application to disrupt