### PR TITLE
Bug 2097186: add rbac roles for the podsecuritylabelsyncer even outside bootkube

### DIFF
--- a/bindata/assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrole.yaml
+++ b/bindata/assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrole.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  name: system:openshift:controller:podsecurity-admission-label-syncer-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch

--- a/bindata/assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrolebinding.yaml
+++ b/bindata/assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  name: system:openshift:controller:podsecurity-admission-label-syncer-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:controller:podsecurity-admission-label-syncer-controller
+subjects:
+- kind: ServiceAccount
+  name: podsecurity-admission-label-syncer-controller
+  namespace: openshift-infra

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -93,6 +93,8 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			"assets/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml",
 			"assets/kube-controller-manager/namespace-security-allocation-controller-clusterrole.yaml",
 			"assets/kube-controller-manager/namespace-security-allocation-controller-clusterrolebinding.yaml",
+			"assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrole.yaml",
+			"assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrolebinding.yaml",
 			"assets/kube-controller-manager/namespace-openshift-infra.yaml",
 			"assets/kube-controller-manager/svc.yaml",
 			"assets/kube-controller-manager/sa.yaml",


### PR DESCRIPTION
These were missing in upgraded clusters.

/assign @soltysh 