### PR TITLE
detect ObjectDeletion and ObjectOrphaning errors by Alerts and  by GC watcher

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -48,3 +48,21 @@ spec:
           for: 60m
           labels:
             severity: warning
+        - alert: GarbageCollectorObjectDeletionFailed
+          annotations:
+            summary: There was a problem with deleting an object.
+            description: Garbage Collector had some problems when attempting to delete an object. Please see KubeControllerManager logs for more details.
+          expr: |
+            garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_count - ignoring(le) garbagecollector_controller_attempt_to_delete_queue_retry_since_seconds_bucket{le="100"} > 0
+          for: 60m
+          labels:
+            severity: warning
+        - alert: GarbageCollectorObjectOrphaningFailed
+          annotations:
+            summary: There was a problem with orphaning an object.
+            description: Garbage Collector had a problem when attempting to orphan an object. Please see KubeControllerManager logs for more details.
+          expr: |
+            garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_count - ignoring(le) garbagecollector_controller_attempt_to_orphan_queue_retry_since_seconds_bucket{le="100"} > 0
+          for: 60m
+          labels:
+            severity: warning

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -264,6 +264,8 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	gcWatcherController := gcwatchercontroller.NewGarbageCollectorWatcherController(operatorClient, kubeInformersForNamespaces, kubeClient, cc.EventRecorder, []string{
 		"GarbageCollectorSyncFailed",
+		"GarbageCollectorObjectDeletionFailed",
+		"GarbageCollectorObjectOrphaningFailed",
 	})
 
 	configInformers.Start(ctx.Done())


### PR DESCRIPTION
This is dependendent on upstream changes in https://github.com/kubernetes/kubernetes/pull/110329

Original adjacent discussion for these new metrics: https://github.com/openshift/cluster-kube-controller-manager-operator/pull/623#discussion_r871633087