### PR TITLE
Bug 2101843: Label openshift-infra namespace as privileged

### DIFF
--- a/bindata/assets/kube-controller-manager/namespace-openshift-infra.yaml
+++ b/bindata/assets/kube-controller-manager/namespace-openshift-infra.yaml
@@ -4,3 +4,7 @@ metadata:
   annotations:
     workload.openshift.io/allowed: "management"
   name: openshift-infra
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/bindata/bootkube/manifests/0000_00_namespace-openshift-infra.yaml
+++ b/bindata/bootkube/manifests/0000_00_namespace-openshift-infra.yaml
@@ -5,6 +5,6 @@ metadata:
     workload.openshift.io/allowed: "management"
   name: openshift-infra
   labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
`baseline` is not enough for the recycler pod.

Without this PR:

```
Events:
  Type     Reason               Age   From                         Message
  ----     ------               ----  ----                         -------
  Warning  VolumeFailedRecycle  23s   persistentvolume-controller  Recycle failed: unexpected error creating recycler pod:  pods "recycler-for-pv0001" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volume "vol")
```

With this PR:

```
Events:
  Type    Reason          Age   From                         Message
  ----    ------          ----  ----                         -------
  Normal  RecyclerPod     11m   persistentvolume-controller  Recycler pod: Successfully assigned openshift-infra/recycler-for-pv0001 to ci-ln-clddrdk-72292-dftbl-worker-a-t47t2 by ci-ln-clddrdk-72292-dftbl-master-1
  Normal  RecyclerPod     11m   persistentvolume-controller  Recycler pod: Add eth0 [10.129.2.16/23] from ovn-kubernetes
  Normal  RecyclerPod     11m   persistentvolume-controller  Recycler pod: Pulling image "registry.build05.ci.openshift.org/ci-ln-clddrdk/stable@sha256:d62aad2b81fff7a848ef78603cd00e4f687e2d6b9bdb77080ce3c126b320971e"
  Normal  RecyclerPod     11m   persistentvolume-controller  Recycler pod: Successfully pulled image "registry.build05.ci.openshift.org/ci-ln-clddrdk/stable@sha256:d62aad2b81fff7a848ef78603cd00e4f687e2d6b9bdb77080ce3c126b320971e" in 6.089471936s
  Normal  RecyclerPod     11m   persistentvolume-controller  Recycler pod: Created container recycler-container
  Normal  RecyclerPod     11m   persistentvolume-controller  Recycler pod: Started container recycler-container
  Normal  VolumeRecycled  11m   persistentvolume-controller  Volume recycled
```

CC @openshift/storage 