### PR TITLE
bootstrap-kube-controller-manager: specify resources.requests

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -27,6 +27,10 @@ spec:
     - --v=2
     - --log-file=/var/log/bootstrap-control-plane/kube-controller-manager.log
 {{ .ExtendedArguments }}
+    resources:
+      requests:
+        memory: 200Mi
+        cpu: 60m
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
@@ -84,6 +88,10 @@ spec:
     - --alsologtostderr
     - --v=2
     - --log-file=/var/log/bootstrap-control-plane/cluster-policy-controller.log
+    resources:
+      requests:
+        memory: 200Mi
+        cpu: 10m
     ports:
       - containerPort: 10357
     volumeMounts:


### PR DESCRIPTION
To address:
```
Oct 11 21:22:11 cnfde10.ptp.lab.eng.bos.redhat.com bash[13032]: E1011 21:22:11.692287   13032 file.go:236] "Static Pod is managed but errored" err="managed container kube-controller-manager does not have Resource.Requests" name="bootstrap-kube-controller-manager-cnfde10.ptp.lab.eng.bos.redhat.com" namespace="kube-system"
```

Copy-pasting the requests from https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/bindata/assets/kube-controller-manager/pod.yaml