### PR TITLE
OCPBUGS-3283: remove unnecessary RBAC

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -97,8 +97,6 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			"assets/kube-controller-manager/leader-election-rolebinding.yaml",
 			"assets/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml",
 			"assets/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml",
-			"assets/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml",
-			"assets/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml",
 			"assets/kube-controller-manager/namespace-security-allocation-controller-clusterrole.yaml",
 			"assets/kube-controller-manager/namespace-security-allocation-controller-clusterrolebinding.yaml",
 			"assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrole.yaml",
@@ -118,6 +116,19 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient),
 		operatorClient,
 		cc.EventRecorder,
+	).WithConditionalResources(
+		bindata.Asset,
+		[]string{
+			// TODO: remove all of these leader-election entries and files in 4.13
+			"assets/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml",
+			"assets/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml",
+		},
+		func() bool {
+			return false
+		},
+		func() bool {
+			return true
+		},
 	).WithConditionalResources(
 		bindata.Asset,
 		[]string{


### PR DESCRIPTION
- was used for making a switch from configMaps to leases in leader election

we noticed this in https://coreos.slack.com/archives/CC3CZCQHM/p1667571136730989
Also you can see the TODOs in the removed files (that are still present for the controller to work).

- https://github.com/openshift/cluster-kube-controller-manager-operator/blob/08d7aed96479b280a23c1e7c2075c98164fc95bd/bindata/assets/kube-controller-manager/leader-election-kube-controller-manager-role-kube-system.yaml#L5
- https://github.com/openshift/cluster-kube-controller-manager-operator/blob/08d7aed96479b280a23c1e7c2075c98164fc95bd/bindata/assets/kube-controller-manager/leader-election-kube-controller-manager-rolebinding-kube-system.yaml#L5

