### PR TITLE
OCPBUGS-5006: add leader-elect-renew-deadline into defaultconfit.yaml

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -19,6 +19,8 @@ extendedArguments:
   - "true"
   leader-elect-retry-period:
   - "3s"
+  leader-elect-renew-deadline:
+  - "12s"
   leader-elect-resource-lock:
   - "configmapsleases"
   controllers:


### PR DESCRIPTION
The default timeout 5s is not enough to sustain in case of primary DNS failure.
https://issues.redhat.com/browse/OCPBUGS-5006