### PR TITLE
Drop flags removed in k8s 1.26

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -22,8 +22,6 @@ spec:
     args:
     - --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }}
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
-    - --logtostderr=false
-    - --alsologtostderr
     - --v=2
     - --log-file=/var/log/bootstrap-control-plane/kube-controller-manager.log{{ .ExtendedArguments }}
     resources:

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -163,8 +163,6 @@ func TestRenderCommand(t *testing.T) {
 					"spec.containers[0].args": []interface{}{
 						"--openshift-config=/etc/kubernetes/config/kube-controller-manager-config.yaml",
 						"--kubeconfig=/etc/kubernetes/secrets/kubeconfig",
-						"--logtostderr=false",
-						"--alsologtostderr",
 						"--v=2",
 						"--log-file=/var/log/bootstrap-control-plane/kube-controller-manager.log",
 						"--allocate-node-cidrs=false",


### PR DESCRIPTION
These flags were removed in https://github.com/kubernetes/kubernetes/pull/112120, based on [the defaults](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md#logging-defaults)  we should be good with just dropping these flags. 