### PR TITLE
Try to query rules before returning the prometheus client

### DIFF
--- a/pkg/operator/gcwatchercontroller/prometheus_client.go
+++ b/pkg/operator/gcwatchercontroller/prometheus_client.go
@@ -62,6 +62,7 @@ func newPrometheusClient(ctx context.Context, configMapClient corev1client.Confi
 	if err != nil {
 		return nil, nil, err
 	}
-
-	return prometheusv1.NewAPI(client), t, nil
+	prometheusClient := prometheusv1.NewAPI(client)
+	_, err = prometheusClient.Rules(ctx)
+	return prometheusClient, t, err
 }


### PR DESCRIPTION
During the cluster installation kube-controller-manager cluster operator is degraded for a few minutes due to:
```
GarbageCollectorDegraded: error fetching rules: Get "https://thanos-querier.openshift-monitoring.svc:9091/api/v1/rules": dial tcp 172.30.119.108:9091: connect: connection refused
```
The GarbageCollectorDegraded status is set to true because the prometheusClient is successfully initialized, but gets a connection refused once we try to query the rules.
Note that as long the client initialization fails the kube-controller-manger won't set the  GarbageCollectorDegraded to true.