### PR TITLE
[OCPCLOUD-1988] Update library-go dependency to move AWS to out of tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	k8s.io/klog/v2 v2.80.1
 )
 
+replace github.com/openshift/library-go => github.com/JoelSpeed/library-go v0.0.0-20230307115500-45b41bd4cffd
+
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/JoelSpeed/library-go v0.0.0-20230307115500-45b41bd4cffd h1:ZmZo8UCN0brXbKkjrSkw2XoUP00C6AuBl5rxFcOLkWo=
+github.com/JoelSpeed/library-go v0.0.0-20230307115500-45b41bd4cffd/go.mod h1:xO4nAf0qa56dgvEJWVD1WuwSJ8JWPU1TYLBQrlutWnE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
@@ -430,8 +432,6 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/openshift/library-go v0.0.0-20230130121854-13dc1e57ef79 h1:IaHw6R25M1sUGd8cbsZ3dhxco3B9ah2QTyopcZUi4CA=
-github.com/openshift/library-go v0.0.0-20230130121854-13dc1e57ef79/go.mod h1:xO4nAf0qa56dgvEJWVD1WuwSJ8JWPU1TYLBQrlutWnE=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -22,8 +22,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		return false, fmt.Errorf("platformStatus is required")
 	}
 	switch platformStatus.Type {
-	case configv1.AWSPlatformType,
-		configv1.GCPPlatformType:
+	case configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AzurePlatformType:
@@ -32,6 +31,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		}
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
+		configv1.AWSPlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,

--- a/vendor/github.com/openshift/library-go/pkg/config/leaderelection/leaderelection.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/leaderelection/leaderelection.go
@@ -22,15 +22,17 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-// ToLeaderElectionWithConfigmapLease returns a "configmapsleases" based leader
+// ToLeaderElectionWithLease returns a "leases" based leader
 // election config that you just need to fill in the Callback for.
-// It is compatible with a "configmaps" based leader election and
-// paves the way toward using "leases" based leader election.
+// NOTE: we had switched from "configmaps" to "configmapsleases"
+// to give an opportunity for the operators to migrate in a
+// backward compatible way. The final step in the migration is
+// switch to using Leases.
 // See https://github.com/kubernetes/kubernetes/issues/107454 for
 // details on how to migrate to "leases" leader election.
+//
 // Don't forget the callbacks!
-// TODO: In the next version we should switch to using "leases"
-func ToLeaderElectionWithConfigmapLease(clientConfig *rest.Config, config configv1.LeaderElection, component, identity string) (leaderelection.LeaderElectionConfig, error) {
+func ToLeaderElectionWithLease(clientConfig *rest.Config, config configv1.LeaderElection, component, identity string) (leaderelection.LeaderElectionConfig, error) {
 	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return leaderelection.LeaderElectionConfig{}, err
@@ -57,7 +59,7 @@ func ToLeaderElectionWithConfigmapLease(clientConfig *rest.Config, config config
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(clientgoscheme.Scheme, corev1.EventSource{Component: component})
 	rl, err := resourcelock.New(
-		resourcelock.ConfigMapsLeasesResourceLock,
+		resourcelock.LeasesResourceLock,
 		config.Namespace,
 		config.Name,
 		kubeClient.CoreV1(),

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -329,7 +329,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	leaderConfig := rest.CopyConfig(protoConfig)
 	leaderConfig.Timeout = b.leaderElection.RenewDeadline.Duration
 
-	leaderElection, err := leaderelectionconverter.ToLeaderElectionWithConfigmapLease(leaderConfig, *b.leaderElection, b.componentName, b.instanceIdentity)
+	leaderElection, err := leaderelectionconverter.ToLeaderElectionWithLease(leaderConfig, *b.leaderElection, b.componentName, b.instanceIdentity)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/crypto/keys.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/crypto/keys.go
@@ -9,6 +9,7 @@ import (
 var (
 	ModeToNewKeyFunc = map[state.Mode]func() []byte{
 		state.AESCBC:    NewAES256Key,
+		state.AESGCM:    NewAES256Key,
 		state.SecretBox: NewAES256Key, // secretbox requires a 32 byte key so we can reuse the same function here
 		state.Identity:  NewIdentityKey,
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
@@ -56,7 +56,8 @@ type Mode string
 // These values are encoded into the secret and thus must not be changed.
 // Strings are used over iota because they are easier for a human to understand.
 const (
-	AESCBC    Mode = "aescbc"    // available from the first release, see defaultMode below
+	AESCBC    Mode = "aescbc" // available from the first release, see defaultMode below
+	AESGCM    Mode = "aesgcm"
 	SecretBox Mode = "secretbox" // available from the first release, see defaultMode below
 	Identity  Mode = "identity"  // available from the first release, see defaultMode below
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -150,7 +150,17 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 			if klog.V(4).Enabled() {
 				klog.Infof("configmap %q changes for revision %d: %s", cm.Name, revision, resourceapply.JSONPatchNoError(existing, required))
 			}
-			configChanges = append(configChanges, fmt.Sprintf("configmap/%s has changed", cm.Name))
+			// "configmap/foo has changed" when there is actual change in data
+			// "configmap/foo has been created" when the existing configmap was empty (iow. the configmap is optional)
+			verb := "changed"
+			if len(existingData) == 0 {
+				verb = "been created"
+			}
+			req := "required"
+			if cm.Optional {
+				req = "optional"
+			}
+			configChanges = append(configChanges, fmt.Sprintf("%s configmap/%s has %s", req, cm.Name, verb))
 		}
 	}
 
@@ -177,7 +187,17 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 			if klog.V(4).Enabled() {
 				klog.Infof("Secret %q changes for revision %d: %s", s.Name, revision, resourceapply.JSONPatchSecretNoError(existing, required))
 			}
-			secretChanges = append(secretChanges, fmt.Sprintf("secret/%s has changed", s.Name))
+			// "configmap/foo has changed" when there is actual change in data
+			// "configmap/foo has been created" when the existing configmap was empty (iow. the configmap is optional)
+			verb := "changed"
+			if len(existingData) == 0 {
+				verb = "been created"
+			}
+			req := "required"
+			if s.Optional {
+				req = "optional"
+			}
+			secretChanges = append(secretChanges, fmt.Sprintf("%s secret/%s has %s", req, s.Name, verb))
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,7 +297,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20230130121854-13dc1e57ef79
+# github.com/openshift/library-go v0.0.0-20230130121854-13dc1e57ef79 => github.com/JoelSpeed/library-go v0.0.0-20230307115500-45b41bd4cffd
 ## explicit; go 1.19
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
@@ -1345,3 +1345,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/openshift/library-go => github.com/JoelSpeed/library-go v0.0.0-20230307115500-45b41bd4cffd


### PR DESCRIPTION
This PR updates the library-go dependency to include [a bump to move the AWS cloud provider to out-of-tree](https://github.com/openshift/library-go/pull/1485). Note this PR must be merged at the same time as a [PR to CCMO](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/232) making the same bump to avoid a build that contains only one of the two bumps.

Tested with [Cluster Bot](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1633075931457261568)