### PR TITLE
OCPBUGS-7785: migrate to using lease objects for leader election

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -20,9 +20,9 @@ extendedArguments:
   leader-elect-retry-period:
   - "3s"
   leader-elect-resource-lock:
-  - "configmapsleases"
+  - "leases"
   leader-elect-renew-deadline:
-  - "12s" # Increase api call timeout value from default 5s to 6s, required in case primary dns server fail.  
+  - "12s" # Increase api call timeout value from default 5s to 6s, required in case primary dns server fail.
   controllers:
   - "*"
   - "-ttl" # TODO: this is excluded in kube-core, but not in #21092

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -185,7 +185,7 @@ func TestRenderCommand(t *testing.T) {
 						"--kube-api-burst=300",
 						"--kube-api-qps=150",
 						"--leader-elect-renew-deadline=12s",
-						"--leader-elect-resource-lock=configmapsleases",
+						"--leader-elect-resource-lock=leases",
 						"--leader-elect-retry-period=3s",
 						"--leader-elect=true",
 						"--pv-recycler-pod-template-filepath-hostpath=",


### PR DESCRIPTION
Manually picked of https://github.com/openshift/cluster-kube-controller-manager-operator/pull/715
/assign @tkashem 