### PR TITLE
revert azure out of tree cloud provider changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	k8s.io/klog/v2 v2.80.1
 )
 
+replace github.com/openshift/library-go => github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e
+
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e h1:84t97UoskpaRMX8esqEXbpShJjfIIvHR4izP0Fl47AM=
+github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e/go.mod h1:OspkL5FZZapzNcka6UkNMFD7ifLT/dWUNvtwErpRK9k=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -430,8 +432,6 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011 h1:RL6hf0cNc9uVZXQkU74a/J91XEo5iip2mWvJTwKgMg4=
-github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011/go.mod h1:OspkL5FZZapzNcka6UkNMFD7ifLT/dWUNvtwErpRK9k=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
@@ -49,10 +49,7 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			configv1.AzurePlatformType,
 			defaultFeatureGate,
 			map[string]interface{}{},
-			map[string]interface{}{
-				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"azure"},
-				}},
+			map[string]interface{}{},
 			false,
 		},
 		{

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -25,9 +25,13 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	case configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
+	case configv1.AzurePlatformType:
+		if isAzureStackHub(platformStatus) {
+			return true, nil
+		}
+		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
-		configv1.AzurePlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -39,6 +43,10 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
+}
+
+func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
+	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }
 
 // isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -45,6 +46,19 @@ type ControllerCommandConfig struct {
 
 	// DisableLeaderElection allows leader election to be suspended
 	DisableLeaderElection bool
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack.
+	LeaseDuration metav1.Duration
+
+	// RenewDeadline is the duration that the acting controlplane will retry
+	// refreshing leadership before giving up.
+	RenewDeadline metav1.Duration
+
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions.
+	RetryPeriod metav1.Duration
 
 	ComponentOwnerReference *corev1.ObjectReference
 }
@@ -277,6 +291,9 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 	}()
 
 	config.LeaderElection.Disable = c.DisableLeaderElection
+	config.LeaderElection.LeaseDuration = c.LeaseDuration
+	config.LeaderElection.RenewDeadline = c.RenewDeadline
+	config.LeaderElection.RetryPeriod = c.RetryPeriod
 
 	builder := NewController(c.componentName, c.startFunc).
 		WithKubeConfigFile(c.basicFlags.KubeConfigFile, nil).

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
@@ -1,0 +1,278 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"time"
+
+	v1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type FeatureGateChangeHandlerFunc func(featureChange FeatureChange)
+
+type FeatureGateAccess interface {
+	SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc)
+
+	Run(ctx context.Context)
+	InitialFeatureGatesObserved() chan struct{}
+	CurrentFeatureGates() (enabled []string, disabled []string, err error)
+	AreInitialFeatureGatesObserved() bool
+}
+
+type Features struct {
+	Enabled  []string
+	Disabled []string
+}
+
+type FeatureChange struct {
+	Previous *Features
+	New      Features
+}
+
+type defaultFeatureGateAccess struct {
+	desiredVersion              string
+	missingVersionMarker        string
+	clusterVersionLister        configlistersv1.ClusterVersionLister
+	featureGateLister           configlistersv1.FeatureGateLister
+	initialFeatureGatesObserved chan struct{}
+
+	featureGateChangeHandlerFn FeatureGateChangeHandlerFunc
+
+	lock            sync.Mutex
+	started         bool
+	initialFeatures Features
+	currentFeatures Features
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+}
+
+// NewFeatureGateAccess returns a controller that keeps the list of enabled/disabled featuregates up to date.
+// desiredVersion is the version of this operator that would be set on the clusteroperator.status.versions.
+// missingVersionMarker is the stub version provided by the operator.  If that is also the desired version,
+// then the most either the desired clusterVersion or most recent version will be used.
+// clusterVersionInformer is used when desiredVersion and missingVersionMarker are the same to derive the "best" version
+// of featuregates to use.
+// featureGateInformer is used to track changes to the featureGates once they are initially set.
+// By default, when the enabled/disabled list  of featuregates changes, os.Exit is called.  This behavior can be
+// overridden by calling SetChangeHandler to whatever you wish the behavior to be.
+// A common construct is:
+/* go
+featureGateAccessor := NewFeatureGateAccess(args)
+go featureGateAccessor.Run(ctx)
+
+select{
+case <- featureGateAccessor.InitialFeatureGatesObserved():
+	enabled, disabled, _ := featureGateAccessor.CurrentFeatureGates()
+	klog.Infof("FeatureGates initialized: enabled=%v  disabled=%v", enabled, disabled)
+case <- time.After(1*time.Minute):
+	klog.Errorf("timed out waiting for FeatureGate detection")
+	return fmt.Errorf("timed out waiting for FeatureGate detection")
+}
+
+// whatever other initialization you have to do, at this point you have FeatureGates to drive your behavior.
+*/
+// That construct is easy.  It is better to use the .spec.observedConfiguration construct common in library-go operators
+// to avoid gating your general startup on FeatureGate determination, but if you haven't already got that mechanism
+// this construct is easy.
+func NewFeatureGateAccess(
+	desiredVersion, missingVersionMarker string,
+	clusterVersionInformer v1.ClusterVersionInformer,
+	featureGateInformer v1.FeatureGateInformer,
+	eventRecorder events.Recorder) FeatureGateAccess {
+	c := &defaultFeatureGateAccess{
+		desiredVersion:              desiredVersion,
+		missingVersionMarker:        missingVersionMarker,
+		clusterVersionLister:        clusterVersionInformer.Lister(),
+		featureGateLister:           featureGateInformer.Lister(),
+		initialFeatureGatesObserved: make(chan struct{}),
+		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "feature-gate-detector"),
+		eventRecorder:               eventRecorder,
+	}
+	c.SetChangeHandler(ForceExit)
+
+	// we aren't expecting many
+	clusterVersionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+	featureGateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+
+	return c
+}
+
+func ForceExit(featureChange FeatureChange) {
+	if featureChange.Previous != nil {
+		os.Exit(0)
+	}
+}
+
+func (c *defaultFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.started {
+		panic("programmer error, cannot update the change handler after starting")
+	}
+	c.featureGateChangeHandlerFn = featureGateChangeHandlerFn
+}
+
+func (c *defaultFeatureGateAccess) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting feature-gate-detector")
+	defer klog.Infof("Shutting down feature-gate-detector")
+
+	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+
+	<-ctx.Done()
+}
+
+func (c *defaultFeatureGateAccess) syncHandler(ctx context.Context) error {
+	desiredVersion := c.desiredVersion
+	if c.missingVersionMarker == c.desiredVersion {
+		clusterVersion, err := c.clusterVersionLister.Get("version")
+		if apierrors.IsNotFound(err) {
+			return nil // we will be re-triggered when it is created
+		}
+		if err != nil {
+			return err
+		}
+
+		desiredVersion = clusterVersion.Status.Desired.Version
+		if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+			desiredVersion = clusterVersion.Status.History[0].Version
+		}
+	}
+
+	featureGate, err := c.featureGateLister.Get("cluster")
+	if apierrors.IsNotFound(err) {
+		return nil // we will be re-triggered when it is created
+	}
+	if err != nil {
+		return err
+	}
+
+	features := Features{}
+	enabled, disabled, err := FeaturesGatesFromFeatureSets(featureGate)
+	if err != nil {
+		return err
+	}
+	features.Enabled = enabled
+	features.Disabled = disabled
+
+	c.setFeatureGates(features)
+
+	return nil
+}
+
+func (c *defaultFeatureGateAccess) setFeatureGates(features Features) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var previousFeatures *Features
+	if c.AreInitialFeatureGatesObserved() {
+		t := c.currentFeatures
+		previousFeatures = &t
+	}
+
+	c.currentFeatures = features
+
+	if !c.AreInitialFeatureGatesObserved() {
+		c.initialFeatures = features
+		close(c.initialFeatureGatesObserved)
+		c.eventRecorder.Eventf("FeatureGatesInitialized", "FeatureGates updated to %#v", c.currentFeatures)
+	}
+
+	if previousFeatures == nil || !reflect.DeepEqual(*previousFeatures, c.currentFeatures) {
+		if previousFeatures != nil {
+			c.eventRecorder.Eventf("FeatureGatesModified", "FeatureGates updated to %#v", c.currentFeatures)
+		}
+
+		c.featureGateChangeHandlerFn(FeatureChange{
+			Previous: previousFeatures,
+			New:      c.currentFeatures,
+		})
+	}
+}
+
+func (c *defaultFeatureGateAccess) InitialFeatureGatesObserved() chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *defaultFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *defaultFeatureGateAccess) CurrentFeatureGates() ([]string, []string, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.AreInitialFeatureGatesObserved() {
+		return nil, nil, fmt.Errorf("featureGates not yet observed")
+	}
+	retEnabled := make([]string, len(c.currentFeatures.Enabled))
+	retDisabled := make([]string, len(c.currentFeatures.Disabled))
+	copy(retEnabled, c.currentFeatures.Enabled)
+	copy(retDisabled, c.currentFeatures.Disabled)
+
+	return retEnabled, retDisabled, nil
+}
+
+func (c *defaultFeatureGateAccess) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *defaultFeatureGateAccess) processNextWorkItem(ctx context.Context) bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.syncHandler(ctx)
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,7 +297,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011
+# github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011 => github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e
 ## explicit; go 1.19
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
@@ -1345,3 +1345,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/openshift/library-go => github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e


### PR DESCRIPTION
Revert relevant portions of https://github.com/openshift/cluster-kube-controller-manager-operator/pull/705 to compare impact related to OCPBUGS-11308

Must be merged along with https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/241 to ensure functioning clusters.  If not merged at the same time clusters resulting from the build will be in an invalid and unstable state.