### PR TITLE
[OCPCLOUD-2034] Update cloud provider tests with feature gate changes

### DIFF
--- a/cmd/cluster-kube-controller-manager-operator/main.go
+++ b/cmd/cluster-kube-controller-manager-operator/main.go
@@ -36,7 +36,7 @@ func NewSSCSCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.AddCommand(operatorcmd.NewOperator())
-	cmd.AddCommand(render.NewRenderCommand(os.Stderr))
+	cmd.AddCommand(render.NewRenderCommand(nil))
 	cmd.AddCommand(installerpod.NewInstaller(ctx))
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())

--- a/pkg/cmd/render/testdata/rendered/custom-fg/featuregate-custom.yaml
+++ b/pkg/cmd/render/testdata/rendered/custom-fg/featuregate-custom.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled:
+    - AwesomeNewFeature
+    disabled:
+    - BadFailingFeature
+status:
+  featureGates:
+  - version: "test"
+    enabled:
+    - name: AwesomeNewFeature
+    disabled:
+    - name: BadFailingFeature

--- a/pkg/cmd/render/testdata/rendered/default-fg/featuregate.yaml
+++ b/pkg/cmd/render/testdata/rendered/default-fg/featuregate.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+status:
+  featureGates:
+  - version: "test"
+    enabled:
+    - name: Foo
+    disabled:
+    - name: Bar

--- a/pkg/cmd/render/testdata/rendered/duplicate-fg/featuregate-copy.yaml
+++ b/pkg/cmd/render/testdata/rendered/duplicate-fg/featuregate-copy.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+status:
+  featureGates:
+  - version: "test"
+    enabled:
+    - name: Foo
+    disabled:
+    - name: Bar

--- a/pkg/cmd/render/testdata/rendered/duplicate-fg/featuregate.yaml
+++ b/pkg/cmd/render/testdata/rendered/duplicate-fg/featuregate.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+status:
+  featureGates:
+  - version: "test"
+    enabled:
+    - name: Foo
+    disabled:
+    - name: Bar

--- a/pkg/cmd/render/testdata/rendered/mismatched-fg/featuregate-custom.yaml
+++ b/pkg/cmd/render/testdata/rendered/mismatched-fg/featuregate-custom.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled:
+    - Foo
+    disabled:
+    - Bar
+status:
+  featureGates:
+  - version: "test"
+    enabled:
+    - name: Foo
+    disabled:
+    - name: Bar

--- a/pkg/cmd/render/testdata/rendered/mismatched-fg/featuregate.yaml
+++ b/pkg/cmd/render/testdata/rendered/mismatched-fg/featuregate.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+status:
+  featureGates:
+  - version: "test"
+    enabled:
+    - name: Foo
+    disabled:
+    - name: Bar

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
@@ -1,13 +1,13 @@
 package cloud
 
 import (
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
@@ -1,9 +1,11 @@
 package cloud
 
 import (
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"reflect"
 	"testing"
+
+	"github.com/openshift/library-go/pkg/cloudprovider"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -55,13 +57,47 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			configv1.AzurePlatformType,
 			featuregates.NewHardcodedFeatureGateAccess(
 				[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProviderAzure,
+					configv1.FeatureGateExternalCloudProviderGCP,
+				},
 			),
 			map[string]interface{}{},
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
 					"external-cloud-volume-plugin": []interface{}{"azure"},
 				}},
+			false,
+		},
+		{
+			"With cloud specific FG, on Tech Preview platform (Azure)",
+			configv1.AzurePlatformType,
+			featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureAzure},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProvider,
+					configv1.FeatureGateExternalCloudProviderGCP,
+				},
+			),
+			map[string]interface{}{},
+			map[string]interface{}{
+				"extendedArguments": map[string]interface{}{
+					"external-cloud-volume-plugin": []interface{}{"azure"},
+				}},
+			false,
+		},
+		{
+			"With wrong cloud specific FG, on Tech Preview platform (Azure)",
+			configv1.AzurePlatformType,
+			featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureGCP},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProvider,
+					configv1.FeatureGateExternalCloudProviderAzure,
+				},
+			),
+			map[string]interface{}{},
+			map[string]interface{}{},
 			false,
 		},
 		{
@@ -88,13 +124,47 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			configv1.GCPPlatformType,
 			featuregates.NewHardcodedFeatureGateAccess(
 				[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProviderAzure,
+					configv1.FeatureGateExternalCloudProviderGCP,
+				},
 			),
 			map[string]interface{}{},
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
 					"external-cloud-volume-plugin": []interface{}{"gce"},
 				}},
+			false,
+		},
+		{
+			"With cloud specific FG, on Tech Preview platform (GCP)",
+			configv1.GCPPlatformType,
+			featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureGCP},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProvider,
+					configv1.FeatureGateExternalCloudProviderAzure,
+				},
+			),
+			map[string]interface{}{},
+			map[string]interface{}{
+				"extendedArguments": map[string]interface{}{
+					"external-cloud-volume-plugin": []interface{}{"gce"},
+				}},
+			false,
+		},
+		{
+			"With wrong cloud specific FG, on Tech Preview platform (GCP)",
+			configv1.GCPPlatformType,
+			featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureAzure},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProvider,
+					configv1.FeatureGateExternalCloudProviderGCP,
+				},
+			),
+			map[string]interface{}{},
+			map[string]interface{}{},
 			false,
 		},
 		{
@@ -113,7 +183,10 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			configv1.LibvirtPlatformType,
 			featuregates.NewHardcodedFeatureGateAccess(
 				[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					configv1.FeatureGateExternalCloudProviderAzure,
+					configv1.FeatureGateExternalCloudProviderGCP,
+				},
 			),
 			map[string]interface{}{},
 			map[string]interface{}{},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"os"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/targetconfigcontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/latencyprofilecontroller"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"


### PR DESCRIPTION
This updates the cloud provider and external volume plugin config observers to use the new feature gates accessor interface. This will allow the feature gate status observation to be determined by the cluster config operator in a synchronised way across the multiple interested operators.

Required to get Azure and GCP CCMs to be promotable in a single PR.

/hold until library-go PR is merged

CC @deads2k 