### PR TITLE
 [release-4.13] OCPBUGS-11353: AWS should not use external-cloud-volume-plugin post CSI migration

### DIFF
--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
@@ -40,11 +40,17 @@ func ObserveCloudVolumePlugin(genericListers configobserver.Listers, recorder ev
 	observedConfig := map[string]interface{}{}
 	cloudProvider := cloudprovider.GetPlatformName(infrastructure.Status.PlatformStatus.Type, recorder)
 
-	// If the cloud provider is external, we should set the option, else leave it empty.
-	if external && len(cloudProvider) > 0 {
-		if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, volumePluginPath...); err != nil {
-			recorder.Warningf("ObserveCloudVolumePlugin", "Failed setting cloudVolumePlugin: %v", err)
-			return existingConfig, append(errs, err)
+	switch cloudProvider {
+	case "aws":
+		// CSI migration GA'd more than 1 release ago, so we can safely remove the in-tree plugin.
+		// Do nothing on these platforms.
+	default:
+		// If the cloud provider is external, we should set the option, else leave it empty.
+		if external && len(cloudProvider) > 0 {
+			if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, volumePluginPath...); err != nil {
+				recorder.Warningf("ObserveCloudVolumePlugin", "Failed setting cloudVolumePlugin: %v", err)
+				return existingConfig, append(errs, err)
+			}
 		}
 	}
 

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
@@ -17,6 +17,17 @@ import (
 )
 
 func TestObserveCloudVolumePlugin(t *testing.T) {
+	defaultFeatureGate := &configv1.FeatureGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.FeatureGateSpec{
+			FeatureGateSelection: configv1.FeatureGateSelection{
+				FeatureSet: configv1.Default,
+			},
+		},
+	}
+
 	type Test struct {
 		name            string
 		platform        configv1.PlatformType
@@ -26,16 +37,24 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 	}
 	tests := []Test{
 		{
-			"No FG, on Tech Preview platform (AWS)",
+			"Default FG, on GA platform (AWS) post CSI migration",
 			configv1.AWSPlatformType,
-			nil,
+			defaultFeatureGate,
 			map[string]interface{}{},
 			map[string]interface{}{},
 			false,
 		},
 		{
-			"With FG, on Tech Preview platform (AWS)",
-			configv1.AWSPlatformType,
+			"Default FG, on tech preview platform (Azure) pre CSI migration",
+			configv1.AzurePlatformType,
+			defaultFeatureGate,
+			map[string]interface{}{},
+			map[string]interface{}{},
+			false,
+		},
+		{
+			"With FG, on Tech Preview platform (Azure)",
+			configv1.AzurePlatformType,
 			&configv1.FeatureGate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
@@ -52,17 +71,59 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			map[string]interface{}{},
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"aws"},
+					"external-cloud-volume-plugin": []interface{}{"azure"},
 				}},
 			false,
 		},
 		{
-			"With FG removed, on Tech Preview platform (AWS)",
-			configv1.AWSPlatformType,
-			nil,
+			"With FG removed, on Tech Preview platform (Azure)",
+			configv1.AzurePlatformType,
+			defaultFeatureGate,
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"aws"},
+					"external-cloud-volume-plugin": []interface{}{"azure"},
+				}},
+			map[string]interface{}{},
+			false,
+		},
+		{
+			"Default FG, on tech preview platform (GCP) pre CSI migration",
+			configv1.GCPPlatformType,
+			defaultFeatureGate,
+			map[string]interface{}{},
+			map[string]interface{}{},
+			false,
+		},
+		{
+			"With FG, on Tech Preview platform (GCP)",
+			configv1.GCPPlatformType,
+			&configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.CustomNoUpgrade,
+						CustomNoUpgrade: &configv1.CustomFeatureGates{
+							Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+						},
+					},
+				},
+			},
+			map[string]interface{}{},
+			map[string]interface{}{
+				"extendedArguments": map[string]interface{}{
+					"external-cloud-volume-plugin": []interface{}{"gce"},
+				}},
+			false,
+		},
+		{
+			"With FG removed, on Tech Preview platform (GCP)",
+			configv1.GCPPlatformType,
+			defaultFeatureGate,
+			map[string]interface{}{
+				"extendedArguments": map[string]interface{}{
+					"external-cloud-volume-plugin": []interface{}{"gce"},
 				}},
 			map[string]interface{}{},
 			false,


### PR DESCRIPTION
updated azure unit tests for 4.13 to reflect tech preview status.