### PR TITLE
OCPBUGS-13579: remove RBAC for cluster-policy-controller CM leader election

### DIFF
--- a/bindata/assets/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml
+++ b/bindata/assets/kube-controller-manager/leader-election-cluster-policy-controller-role.yaml
@@ -1,20 +1,9 @@
-# This role is necessary to create leader lock configmap and lease for cluster-policy-controller
-# TODO: configmaps should be removed once cluster-policy-controller is moved to exclusively lease lock
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: openshift-kube-controller-manager
   name: system:openshift:leader-election-lock-cluster-policy-controller
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - watch
-  - create
-  - update
 - apiGroups:
   - "coordination.k8s.io"
   resources:

--- a/bindata/assets/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml
+++ b/bindata/assets/kube-controller-manager/leader-election-cluster-policy-controller-rolebinding.yaml
@@ -1,4 +1,3 @@
-# This role is necessary to create leader lock for cluster-policy-controller
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -58,6 +58,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		operatorclient.OperatorNamespace,
 		operatorclient.TargetNamespace,
 		"kube-system",
+		"openshift-infra",
 	)
 
 	operatorClient, dynamicInformers, err := genericoperatorclient.NewStaticPodOperatorClient(cc.KubeConfig, operatorv1.GroupVersion.WithResource("kubecontrollermanagers"))


### PR DESCRIPTION
after a recent kube & library-go update https://github.com/openshift/cluster-policy-controller/pull/113 we no longer need RBAC for configmaps in cluster-policy-controller as we have switched to leases exclusively