### PR TITLE
NO-ISSUE: Render networks as comma-separated value

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -14,12 +14,12 @@ extendedArguments:
   authorization-kubeconfig:
   - "/etc/kubernetes/secrets/kubeconfig"
   {{if .ClusterCIDR }}
-  cluster-cidr: {{range .ClusterCIDR}}
-  - {{.}}{{end}}
+  cluster-cidr:
+  - "{{ range $index, $element := .ClusterCIDR}}{{if $index}},{{end}}{{$element}}{{end}}"
   {{end}}
   {{if .ServiceClusterIPRange }}
-  service-cluster-ip-range: {{range .ServiceClusterIPRange}}
-  - {{.}}{{end}}
+  service-cluster-ip-range:
+  - "{{ range $index, $element := .ServiceClusterIPRange}}{{if $index}},{{end}}{{$element}}{{end}}"
   {{end}}
   pv-recycler-pod-template-filepath-nfs: # bootstrap KCM doesn't need recycler templates
   - ""


### PR DESCRIPTION
We have observed that the current way of rendering cluster and service networks as arrays of value generate the following bootstrap config

```
service-cluster-ip-range:
- 172.30.0.0/16
- fd65:172:16::/112
```

what subsequently creates the following kube-controller-manager pod manifest

```
args:
- --service-cluster-ip-range=172.30.0.0/16
- --service-cluster-ip-range=fd65:172:16::/112
```

what is interpreted as the running process as

```
FLAG: --service-cluster-ip-range="fd65:172:16::/112"
```

with the missing value. The reason for this is that the process takes into account only the last instance of the param and does not concatenate all the values provided.

In order to avoid this we are rendering the networks as a single comma-separated string so that the initial config file will contain now

```
service-cluster-ip-range:
- "172.30.0.0/16,fd65:172:16::/112"
```

Exactly the same pattern applies to the cluster networks that exist under `cluster-cidr` key.

Thanks to this kube-controller-manager process will be running with the correct set of networks.

Contributes-to: OCPBUGS-18641