### PR TITLE
OCPBUGS-21103: Drop flags removed in k8s 1.26 [4.13]

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -80,10 +80,7 @@ spec:
     - --config=/etc/kubernetes/config/{{ .ClusterPolicyControllerConfigFileName }}
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --namespace=$(POD_NAMESPACE)
-    - --logtostderr=false
-    - --alsologtostderr
     - --v=2
-    - --log-file=/var/log/bootstrap-control-plane/cluster-policy-controller.log
     resources:
       requests:
         memory: 200Mi


### PR DESCRIPTION
We forgot to bump kube deps to 1.26 in 4.13. We are required to bump them to fix a https://github.com/openshift/cluster-policy-controller/pull/135 CVE. These changes are required to start a cpc container in the boostrap phase:

```
Previously deprecated klog flags will be removed completely in kube 1.26.
Logs of bootstrap pods were previously using the --log-file flag, will be available in the cri-o container logs instead.
```