### PR TITLE
OCPBUGS-5825: Removes legacy cloud-provider resources

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -138,8 +138,6 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			"assets/kube-controller-manager/localhost-recovery-token.yaml",
 			"assets/kube-controller-manager/csr_approver_clusterrole.yaml",
 			"assets/kube-controller-manager/csr_approver_clusterrolebinding.yaml",
-			"assets/kube-controller-manager/gce/cloud-provider-role.yaml",
-			"assets/kube-controller-manager/gce/cloud-provider-binding.yaml",
 		},
 		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient),
 		operatorClient,
@@ -165,6 +163,21 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			return isVSphere
 		},
 		nil,
+	).WithConditionalResources(
+		bindata.Asset,
+		[]string{
+			"assets/kube-controller-manager/gce/cloud-provider-role.yaml",
+			"assets/kube-controller-manager/gce/cloud-provider-binding.yaml",
+		},
+		func() bool {
+			// We do not want to apply these resources, so must return false here
+			return false
+		},
+		func() bool {
+			// The resources above are required for the 4.14 -> 4.15 upgrade path.
+			// They are not required from 4.16, so can re removed.
+			return true
+		},
 	).AddKubeInformers(kubeInformersForNamespaces)
 
 	targetConfigController := targetconfigcontroller.NewTargetConfigController(


### PR DESCRIPTION
This change removes the cloud-provider ClusterRole, ClusterRoleBinding and ServiceAccount that are no longer required from 4.16