### PR TITLE
OCPCLOUD-2514: Remove reliance on Cloud Provider feature gates for determining if CCM should be deployed.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20231218131639-7a5aa77cc72d
 	github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c
 	github.com/openshift/client-go v0.0.0-20231218140158-47f6d749b9d9
-	github.com/openshift/library-go v0.0.0-20240108202620-5674ec6ced1c
+	github.com/openshift/library-go v0.0.0-20240228143125-4602d24d27bc
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c h1:H5
 github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20231218140158-47f6d749b9d9 h1:kjgW3luAkf9NWu+8u+jqNNbexDG+CY82/INw8hGbG14=
 github.com/openshift/client-go v0.0.0-20231218140158-47f6d749b9d9/go.mod h1:kKmxYRXTMutfF7XzGppFdbLhNGX1brXkRsZx5ID8c7U=
-github.com/openshift/library-go v0.0.0-20240108202620-5674ec6ced1c h1:zGVuYVRf/tflaFHbpyce/12QSQ5K0OElDhVdnEPtHB8=
-github.com/openshift/library-go v0.0.0-20240108202620-5674ec6ced1c/go.mod h1:82B0gt8XawdXWRtKMrm3jSMTeRsiOSYKCi4F0fvPjG0=
+github.com/openshift/library-go v0.0.0-20240228143125-4602d24d27bc h1:HjWxaJz0Gre4cnBCovUBcdzbc97WvBst71Ox6PpkdmU=
+github.com/openshift/library-go v0.0.0-20240228143125-4602d24d27bc/go.mod h1:ePlaOqUiPplRc++6aYdMe+2FmXb2xTNS9Nz5laG2YmI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -84,8 +84,10 @@ func newCertRotationController(
 		certrotation.RotatedSigningCASecret{
 			Namespace: operatorclient.OperatorNamespace,
 			// this is not a typo, this is the signer of the signer
-			Name:                   "csr-signer-signer",
-			JiraComponent:          "kube-controller-manager",
+			Name: "csr-signer-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-controller-manager",
+			},
 			Validity:               60 * rotationDay,
 			Refresh:                30 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -95,18 +97,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "csr-controller-signer-ca",
-			JiraComponent: "kube-controller-manager",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "csr-controller-signer-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-controller-manager",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        configMapsGetter,
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.OperatorNamespace,
-			Name:                   "csr-signer",
-			JiraComponent:          "kube-controller-manager",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "csr-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-controller-manager",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin.go
@@ -5,16 +5,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
-	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
+	cloudproviderobserver "github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-func NewObserveCloudVolumePluginFunc(featureGateAccessor featuregates.FeatureGateAccess) configobserver.ObserveConfigFunc {
-	return (&cloudVolumePlugin{
-		featureGateAccessor: featureGateAccessor,
-	}).ObserveCloudVolumePlugin
+func NewObserveCloudVolumePluginFunc() configobserver.ObserveConfigFunc {
+	return (&cloudVolumePlugin{}).ObserveCloudVolumePlugin
 }
 
 type cloudVolumePlugin struct {
@@ -43,13 +42,13 @@ func (o *cloudVolumePlugin) ObserveCloudVolumePlugin(genericListers configobserv
 		return existingConfig, append(errs, err)
 	}
 
-	external, err := cloudprovider.IsCloudProviderExternal(o.featureGateAccessor, infrastructure.Status.PlatformStatus)
+	external, err := cloudprovider.IsCloudProviderExternal(infrastructure.Status.PlatformStatus)
 	if err != nil {
 		return existingConfig, append(errs, err)
 	}
 
 	observedConfig := map[string]interface{}{}
-	cloudProvider := cloudprovider.GetPlatformName(infrastructure.Status.PlatformStatus.Type, recorder)
+	cloudProvider := cloudproviderobserver.GetPlatformName(infrastructure.Status.PlatformStatus.Type, recorder)
 
 	switch cloudProvider {
 	case "aws":

--- a/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobservation/cloud/observe_cloud_volume_plugin_test.go
@@ -4,9 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/cloudprovider"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -19,49 +16,23 @@ import (
 )
 
 func TestObserveCloudVolumePlugin(t *testing.T) {
-	defaultFeatureGate := featuregates.NewHardcodedFeatureGateAccess(
-		[]configv1.FeatureGateName{},
-		[]configv1.FeatureGateName{
-			configv1.FeatureGateExternalCloudProvider,
-			configv1.FeatureGateExternalCloudProviderAzure,
-			configv1.FeatureGateExternalCloudProviderGCP,
-		},
-	)
-
 	type Test struct {
-		name                string
-		platform            configv1.PlatformType
-		featureGateAccessor featuregates.FeatureGateAccess
-		input, expected     map[string]interface{}
-		expectedError       bool
+		name            string
+		platform        configv1.PlatformType
+		input, expected map[string]interface{}
+		expectedError   bool
 	}
 	tests := []Test{
 		{
-			"Default FG, on GA platform (AWS) post CSI migration",
+			"On GA platform (AWS) post CSI migration",
 			configv1.AWSPlatformType,
-			defaultFeatureGate,
 			map[string]interface{}{},
 			map[string]interface{}{},
 			false,
 		},
 		{
-			"Default FG, on tech preview platform (Azure) pre CSI migration",
+			"On GA platform (Azure) pre CSI migration",
 			configv1.AzurePlatformType,
-			defaultFeatureGate,
-			map[string]interface{}{},
-			map[string]interface{}{},
-			false,
-		},
-		{
-			"With FG, on Tech Preview platform (Azure)",
-			configv1.AzurePlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProviderAzure,
-					configv1.FeatureGateExternalCloudProviderGCP,
-				},
-			),
 			map[string]interface{}{},
 			map[string]interface{}{
 				"extendedArguments": map[string]interface{}{
@@ -70,124 +41,8 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			false,
 		},
 		{
-			"With cloud specific FG, on Tech Preview platform (Azure)",
-			configv1.AzurePlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureAzure},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProvider,
-					configv1.FeatureGateExternalCloudProviderGCP,
-				},
-			),
-			map[string]interface{}{},
-			map[string]interface{}{
-				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"azure"},
-				}},
-			false,
-		},
-		{
-			"With wrong cloud specific FG, on Tech Preview platform (Azure)",
-			configv1.AzurePlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureGCP},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProvider,
-					configv1.FeatureGateExternalCloudProviderAzure,
-				},
-			),
-			map[string]interface{}{},
-			map[string]interface{}{},
-			false,
-		},
-		{
-			"With FG removed, on Tech Preview platform (Azure)",
-			configv1.AzurePlatformType,
-			defaultFeatureGate,
-			map[string]interface{}{
-				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"azure"},
-				}},
-			map[string]interface{}{},
-			false,
-		},
-		{
-			"Default FG, on tech preview platform (GCP) pre CSI migration",
-			configv1.GCPPlatformType,
-			defaultFeatureGate,
-			map[string]interface{}{},
-			map[string]interface{}{},
-			false,
-		},
-		{
-			"With FG, on Tech Preview platform (GCP)",
-			configv1.GCPPlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProviderAzure,
-					configv1.FeatureGateExternalCloudProviderGCP,
-				},
-			),
-			map[string]interface{}{},
-			map[string]interface{}{
-				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"gce"},
-				}},
-			false,
-		},
-		{
-			"With cloud specific FG, on Tech Preview platform (GCP)",
-			configv1.GCPPlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureGCP},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProvider,
-					configv1.FeatureGateExternalCloudProviderAzure,
-				},
-			),
-			map[string]interface{}{},
-			map[string]interface{}{
-				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"gce"},
-				}},
-			false,
-		},
-		{
-			"With wrong cloud specific FG, on Tech Preview platform (GCP)",
-			configv1.GCPPlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeatureAzure},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProvider,
-					configv1.FeatureGateExternalCloudProviderGCP,
-				},
-			),
-			map[string]interface{}{},
-			map[string]interface{}{},
-			false,
-		},
-		{
-			"With FG removed, on Tech Preview platform (GCP)",
-			configv1.GCPPlatformType,
-			defaultFeatureGate,
-			map[string]interface{}{
-				"extendedArguments": map[string]interface{}{
-					"external-cloud-volume-plugin": []interface{}{"gce"},
-				}},
-			map[string]interface{}{},
-			false,
-		},
-		{
-			"With FG, on unsupported platform (libvirt)",
+			"On an unsupported platform (libvirt)",
 			configv1.LibvirtPlatformType,
-			featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-				[]configv1.FeatureGateName{
-					configv1.FeatureGateExternalCloudProviderAzure,
-					configv1.FeatureGateExternalCloudProviderGCP,
-				},
-			),
 			map[string]interface{}{},
 			map[string]interface{}{},
 			false,
@@ -210,19 +65,11 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			featureGates := featuregates.NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{},
-				[]configv1.FeatureGateName{},
-			)
-			if test.featureGateAccessor != nil {
-				featureGates = test.featureGateAccessor
-			}
-
 			listers := configobservation.Listers{
 				InfrastructureLister_: configlistersv1.NewInfrastructureLister(infraIndexer),
 			}
 
-			result, errs := NewObserveCloudVolumePluginFunc(featureGates)(listers, events.NewInMemoryRecorder("cloud"), test.input)
+			result, errs := NewObserveCloudVolumePluginFunc()(listers, events.NewInMemoryRecorder("cloud"), test.input)
 			if len(errs) > 0 && !test.expectedError {
 				t.Fatal(errs)
 			} else if len(errs) == 0 {

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -120,7 +120,6 @@ func NewConfigObserver(
 				false,
 				[]string{"extendedArguments", "cloud-provider"},
 				[]string{"extendedArguments", "cloud-config"},
-				featureGateAccessor,
 			),
 
 			// this is picked up by the kube-controller-manager container
@@ -155,7 +154,7 @@ func NewConfigObserver(
 			serviceca.ObserveServiceCA,
 			clustername.ObserveInfraID,
 			libgoapiserver.ObserveTLSSecurityProfile,
-			cloud.NewObserveCloudVolumePluginFunc(featureGateAccessor),
+			cloud.NewObserveCloudVolumePluginFunc(),
 		),
 	}
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -33,6 +33,7 @@ import (
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
@@ -708,8 +709,9 @@ func manageServiceAccountCABundle(ctx context.Context, lister corev1listers.Conf
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "serviceaccount-ca"},
 		lister,
-		"kube-controller-manager",
-		"",
+		certrotation.AdditionalAnnotations{
+			JiraComponent: "kube-controller-manager",
+		},
 		// include the ca bundle needed to recognize the server
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-server-ca"},
 		// include the ca bundle needed to recognize default
@@ -726,8 +728,9 @@ func ManageCSRCABundle(ctx context.Context, lister corev1listers.ConfigMapLister
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-controller-ca"},
 		lister,
-		"kube-controller-manager",
-		"",
+		certrotation.AdditionalAnnotations{
+			JiraComponent: "kube-controller-manager",
+		},
 		// include the CA we use to sign CSRs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-signer-ca"},
 		// include the CA we use to sign the cert key pairs from from csr-signer

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -3,8 +3,6 @@ package cloudprovider
 import (
 	"fmt"
 
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-
 	configv1 "github.com/openshift/api/config/v1"
 )
 
@@ -27,24 +25,15 @@ var (
 // IsCloudProviderExternal is used to check whether external cloud provider settings should be used in a component.
 // It checks whether the ExternalCloudProvider feature gate is enabled and whether the ExternalCloudProvider feature
 // has been implemented for the platform.
-func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
-	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
-		return false, fmt.Errorf("featureGates have not been read yet")
-	}
+func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus) (bool, error) {
 	if platformStatus == nil {
 		return false, fmt.Errorf("platformStatus is required")
 	}
 	switch platformStatus.Type {
-	case configv1.GCPPlatformType:
-		// Platforms that are external based on feature gate presence
-		return isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureGCP)
-	case configv1.AzurePlatformType:
-		if isAzureStackHub(platformStatus) {
-			return true, nil
-		}
-		return isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureAzure)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
+		configv1.AzurePlatformType,
+		configv1.GCPPlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -53,23 +42,14 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		configv1.VSpherePlatformType:
 		return true, nil
 	case configv1.ExternalPlatformType:
-		return isExternalPlatformCCMEnabled(platformStatus, featureGateAccessor)
+		return isExternalPlatformCCMEnabled(platformStatus)
 	default:
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
 }
 
-func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
-	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
-}
-
-func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus, featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
-	featureEnabled, err := isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureExternal)
-	if err != nil || !featureEnabled {
-		return featureEnabled, err
-	}
-
+func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus) (bool, error) {
 	if platformStatus == nil || platformStatus.External == nil {
 		return false, nil
 	}
@@ -78,24 +58,5 @@ func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus, featu
 		return true, nil
 	}
 
-	return false, nil
-}
-
-// isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current
-// feature set.
-func isExternalFeatureGateEnabled(featureGateAccess featuregates.FeatureGateAccess, featureGateNames ...configv1.FeatureGateName) (bool, error) {
-	featureGates, err := featureGateAccess.CurrentFeatureGates()
-	if err != nil {
-		return false, fmt.Errorf("unable to read current featuregates: %w", err)
-	}
-
-	// If any of the desired feature gates are enabled, then the external cloud provider should be used.
-	for _, featureGateName := range featureGateNames {
-		if featureGates.Enabled(featureGateName) {
-			return true, nil
-		}
-	}
-
-	// No explicit opinion on the feature gate, assume it's not enabled.
 	return false, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -5,30 +5,45 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTLSArtifactObjectMeta(name, namespace, jiraComponent, description string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Namespace: namespace,
-		Name:      name,
-		Annotations: map[string]string{
-			annotations.OpenShiftComponent:   jiraComponent,
-			annotations.OpenShiftDescription: description,
-		},
-	}
+const (
+	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+)
+
+type AdditionalAnnotations struct {
+	// JiraComponent annotates tls artifacts so that owner could be easily found
+	JiraComponent string
+	// Description is a human-readable one sentence description of certificate purpose
+	Description string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
+	// that TLS artifact is correctly regenerated after it has expired
+	AutoRegenerateAfterOfflineExpiry string
 }
 
-// EnsureTLSMetadataUpdate mutates objectMeta setting necessary annotations if unset
-func EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta, jiraComponent, description string) bool {
+func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
 	modified := false
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)
 	}
-	if len(jiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != jiraComponent {
-		meta.Annotations[annotations.OpenShiftComponent] = jiraComponent
+	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
+		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
 		modified = true
 	}
-	if len(description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != description {
-		meta.Annotations[annotations.OpenShiftDescription] = description
+	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
+		meta.Annotations[annotations.OpenShiftDescription] = a.Description
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.Description
 		modified = true
 	}
 	return modified
+}
+
+func NewTLSArtifactObjectMeta(name, namespace string, annotations AdditionalAnnotations) metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	}
+	_ = annotations.EnsureTLSMetadataUpdate(&meta)
+	return meta
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -1,10 +1,12 @@
 package certrotation
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"fmt"
 	"reflect"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -30,11 +32,8 @@ type CABundleConfigMap struct {
 	Name string
 	// Owner is an optional reference to add to the secret that this rotator creates.
 	Owner *metav1.OwnerReference
-	// JiraComponent annotates tls artifacts so that owner could be easily found
-	JiraComponent string
-	// Description is a human-readable one sentence description of certificate purpose
-	Description string
-
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
 	// Plumbing:
 	Informer      corev1informers.ConfigMapInformer
 	Lister        corev1listers.ConfigMapLister
@@ -42,7 +41,7 @@ type CABundleConfigMap struct {
 	EventRecorder events.Recorder
 }
 
-func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
 	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
@@ -55,8 +54,7 @@ func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingC
 		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: NewTLSArtifactObjectMeta(
 			c.Name,
 			c.Namespace,
-			c.JiraComponent,
-			c.Description,
+			c.AdditionalAnnotations,
 		)}
 	}
 
@@ -64,9 +62,7 @@ func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingC
 	if c.Owner != nil {
 		needsMetadataUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
 	}
-	if len(c.JiraComponent) > 0 || len(c.Description) > 0 {
-		needsMetadataUpdate = EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta, c.JiraComponent, c.Description) || needsMetadataUpdate
-	}
+	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(caBundleConfigMap.ResourceVersion) > 0 {
 		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
 		if err != nil {
@@ -139,6 +135,10 @@ func manageCABundleConfigMap(caBundleConfigMap *corev1.ConfigMap, currentSigner 
 		}
 	}
 
+	// sorting ensures we don't continuously swap the certificates in the bundle, which might cause revision rollouts
+	sort.SliceStable(finalCertificates, func(i, j int) bool {
+		return bytes.Compare(finalCertificates[i].Raw, finalCertificates[j].Raw) < 0
+	})
 	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/api/annotations"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,11 +57,8 @@ type RotatedSelfSignedCertKeySecret struct {
 	// certificate is used, early deletion will be catastrophic.
 	Owner *metav1.OwnerReference
 
-	// JiraComponent annotates tls artifacts so that owner could be easily found
-	JiraComponent string
-
-	// Description is a human-readable one sentence description of certificate purpose
-	Description string
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
 
 	// CertCreator does the actual cert generation.
 	CertCreator TargetCertCreator
@@ -89,14 +85,14 @@ type TargetCertRechecker interface {
 	RecheckChannel() <-chan struct{}
 }
 
-func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
+func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) (*corev1.Secret, error) {
 	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one
 	// TODO do the cross signing thing, but this shows the API consumers want and a very simple impl.
 	originalTargetCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return err
+		return nil, err
 	}
 	targetCertKeyPairSecret := originalTargetCertKeyPairSecret.DeepCopy()
 	if apierrors.IsNotFound(err) {
@@ -104,8 +100,7 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 		targetCertKeyPairSecret = &corev1.Secret{ObjectMeta: NewTLSArtifactObjectMeta(
 			c.Name,
 			c.Namespace,
-			c.JiraComponent,
-			c.Description,
+			c.AdditionalAnnotations,
 		)}
 	}
 	targetCertKeyPairSecret.Type = corev1.SecretTypeTLS
@@ -114,32 +109,30 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 	if c.Owner != nil {
 		needsMetadataUpdate = ensureOwnerReference(&targetCertKeyPairSecret.ObjectMeta, c.Owner)
 	}
-	if len(c.JiraComponent) > 0 || len(c.Description) > 0 {
-		needsMetadataUpdate = EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta, c.JiraComponent, c.Description) || needsMetadataUpdate
-	}
+	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(targetCertKeyPairSecret.ResourceVersion) > 0 {
 		_, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	if reason := needNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
+	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
-		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.JiraComponent, c.Description); err != nil {
-			return err
+		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+			return nil, err
 		}
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
 		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
 	}
 
-	return nil
+	return targetCertKeyPairSecret, nil
 }
 
 func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
@@ -217,7 +210,7 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 
 // setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret.  Only one of client, serving, or signer rotation may be specified.
 // TODO refactor with an interface for actually signing and move the one-of check higher in the stack.
-func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, jiraComponent, description string) error {
+func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, annotations AdditionalAnnotations) error {
 	if targetCertKeyPairSecret.Annotations == nil {
 		targetCertKeyPairSecret.Annotations = map[string]string{}
 	}
@@ -244,12 +237,8 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 	targetCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
 	targetCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
 	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
-	if len(jiraComponent) > 0 {
-		targetCertKeyPairSecret.Annotations[annotations.OpenShiftComponent] = jiraComponent
-	}
-	if len(description) > 0 {
-		targetCertKeyPairSecret.Annotations[annotations.OpenShiftDescription] = description
-	}
+
+	_ = annotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
 	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
 
 	return nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -89,6 +89,19 @@ func (c dynamicOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *op
 	}
 	instance := uncastInstance.(*unstructured.Unstructured)
 
+	return getOperatorStateFromInstance(instance)
+}
+
+func (c dynamicOperatorClient) GetOperatorStateWithQuorum(ctx context.Context) (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
+	instance, err := c.client.Get(ctx, c.configName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return getOperatorStateFromInstance(instance)
+}
+
+func getOperatorStateFromInstance(instance *unstructured.Unstructured) (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	spec, err := getOperatorSpecFromUnstructured(instance.UnstructuredContent())
 	if err != nil {
 		return nil, nil, "", err

--- a/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
@@ -48,6 +48,10 @@ func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1
 	}
 	instance := uncastInstance.(*unstructured.Unstructured)
 
+	return getStaticPodOperatorStateFromInstance(instance)
+}
+
+func getStaticPodOperatorStateFromInstance(instance *unstructured.Unstructured) (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
 	spec, err := getStaticPodOperatorSpecFromUnstructured(instance.UnstructuredContent())
 	if err != nil {
 		return nil, nil, "", err
@@ -66,16 +70,7 @@ func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum(ctx 
 		return nil, nil, "", err
 	}
 
-	spec, err := getStaticPodOperatorSpecFromUnstructured(instance.UnstructuredContent())
-	if err != nil {
-		return nil, nil, "", err
-	}
-	status, err := getStaticPodOperatorStatusFromUnstructured(instance.UnstructuredContent())
-	if err != nil {
-		return nil, nil, "", err
-	}
-
-	return spec, status, instance.GetResourceVersion(), nil
+	return getStaticPodOperatorStateFromInstance(instance)
 }
 
 func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
@@ -16,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
 )
 
 // GenericOptions contains the generic render command options.

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -63,7 +63,7 @@ func ApplyMutatingWebhookConfigurationImproved(ctx context.Context, client admis
 	toWrite := existingCopy // shallow copy so the code reads easier
 	toWrite.Webhooks = required.Webhooks
 
-	klog.V(4).Infof("MutatingWebhookConfiguration %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
+	klog.V(2).Infof("MutatingWebhookConfiguration %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
 
 	actual, err := client.MutatingWebhookConfigurations().Update(ctx, toWrite, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
@@ -138,7 +138,7 @@ func ApplyValidatingWebhookConfigurationImproved(ctx context.Context, client adm
 	toWrite := existingCopy // shallow copy so the code reads easier
 	toWrite.Webhooks = required.Webhooks
 
-	klog.V(4).Infof("ValidatingWebhookConfiguration %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
+	klog.V(2).Infof("ValidatingWebhookConfiguration %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
 
 	actual, err := client.ValidatingWebhookConfigurations().Update(ctx, toWrite, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
@@ -33,7 +33,7 @@ func ApplyCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.
 		return existing, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("CustomResourceDefinition %q changes: %s", existing.Name, JSONPatchNoError(existing, existingCopy))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiregistration.go
@@ -42,7 +42,7 @@ func ApplyAPIService(ctx context.Context, client apiregistrationv1client.APIServ
 
 	existingCopy.Spec = required.Spec
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("APIService %q changes: %s", existing.Name, JSONPatchNoError(existing, existingCopy))
 	}
 	actual, err := client.APIServices().Update(ctx, existingCopy, metav1.UpdateOptions{})

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
@@ -150,7 +150,7 @@ func ApplyDeploymentWithForce(ctx context.Context, client appsclientv1.Deploymen
 		toWrite.Spec.Template.Annotations["operator.openshift.io/force"] = forceString
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("Deployment %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, toWrite))
 	}
 
@@ -237,7 +237,7 @@ func ApplyDaemonSetWithForce(ctx context.Context, client appsclientv1.DaemonSets
 		toWrite.Spec.Template.Annotations["operator.openshift.io/force"] = forceString
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("DaemonSet %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, toWrite))
 	}
 	actual, err := client.DaemonSets(required.Namespace).Update(ctx, toWrite, metav1.UpdateOptions{})

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -115,7 +115,7 @@ func ApplyNamespaceImproved(ctx context.Context, client coreclientv1.NamespacesG
 		return existingCopy, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("Namespace %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
@@ -214,7 +214,7 @@ func ApplyPodImproved(ctx context.Context, client coreclientv1.PodsGetter, recor
 		return existingCopy, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("Pod %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}
 
@@ -251,7 +251,7 @@ func ApplyServiceAccountImproved(ctx context.Context, client coreclientv1.Servic
 		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("ServiceAccount %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}
 	actual, err := client.ServiceAccounts(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
@@ -284,17 +284,26 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
+	// injected by cluster-network-operator: https://github.com/openshift/cluster-network-operator/blob/acc819ee0f3424a341b9ad4e1e83ca0a742c230a/docs/architecture.md?L192#configmap-ca-injector
 	caBundleInjected := required.Labels["config.openshift.io/inject-trusted-cabundle"] == "true"
 	_, newCABundleRequired := required.Data["ca-bundle.crt"]
 
+	// injected by service-ca-operator: https://github.com/openshift/service-ca-operator/blob/f409fb9e308ace1e5f8596add187d2239b073e23/README.md#openshift-service-ca-operator
+	serviceCAInjected := required.Annotations["service.beta.openshift.io/inject-cabundle"] == "true"
+	_, newServiceCARequired := required.Data["service-ca.crt"]
+
 	var modifiedKeys []string
 	for existingCopyKey, existingCopyValue := range existingCopy.Data {
-		// if we're injecting a ca-bundle and the required isn't forcing the value, then don't use the value of existing
+		// if we're injecting a ca-bundle or a service-ca and the required isn't forcing the value, then don't use the value of existing
 		// to drive a diff detection. If required has set the value then we need to force the value in order to have apply
 		// behave predictably.
 		if caBundleInjected && !newCABundleRequired && existingCopyKey == "ca-bundle.crt" {
 			continue
 		}
+		if serviceCAInjected && !newServiceCARequired && existingCopyKey == "service-ca.crt" {
+			continue
+		}
+
 		if requiredValue, ok := required.Data[existingCopyKey]; !ok || (existingCopyValue != requiredValue) {
 			modifiedKeys = append(modifiedKeys, "data."+existingCopyKey)
 		}
@@ -337,7 +346,7 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 		sort.Sort(sort.StringSlice(modifiedKeys))
 		details = fmt.Sprintf("cause by changes in %v", strings.Join(modifiedKeys, ","))
 	}
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("ConfigMap %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}
 	reportUpdateEvent(recorder, required, err, details)

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/migration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/migration.go
@@ -35,7 +35,7 @@ func ApplyStorageVersionMigration(ctx context.Context, client migrationclientv1a
 		return existingCopy, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("StorageVersionMigration %q changes: %v", required.Name, JSONPatchNoError(existing, required))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
@@ -82,7 +82,7 @@ func ApplyServiceMonitor(ctx context.Context, client dynamic.Interface, recorder
 		return nil, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 
@@ -127,7 +127,7 @@ func ApplyPrometheusRule(ctx context.Context, client dynamic.Interface, recorder
 		return nil, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("PrometheusRule %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/policy.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/policy.go
@@ -38,7 +38,7 @@ func ApplyPodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisr
 
 	existingCopy.Spec = required.Spec
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("PodDisruptionBudget %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
@@ -50,7 +50,7 @@ func ApplyClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGette
 		existingCopy.Rules = required.Rules
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("ClusterRole %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
@@ -105,7 +105,7 @@ func ApplyClusterRoleBinding(ctx context.Context, client rbacclientv1.ClusterRol
 	existingCopy.Subjects = requiredCopy.Subjects
 	existingCopy.RoleRef = requiredCopy.RoleRef
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("ClusterRoleBinding %q changes: %v", requiredCopy.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
@@ -139,7 +139,7 @@ func ApplyRole(ctx context.Context, client rbacclientv1.RolesGetter, recorder ev
 
 	existingCopy.Rules = required.Rules
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("Role %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 	actual, err := client.Roles(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
@@ -193,7 +193,7 @@ func ApplyRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGette
 	existingCopy.Subjects = requiredCopy.Subjects
 	existingCopy.RoleRef = requiredCopy.RoleRef
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("RoleBinding %q changes: %v", requiredCopy.Namespace+"/"+requiredCopy.Name, JSONPatchNoError(existing, existingCopy))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -77,7 +77,7 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 		return existing, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("StorageClass %q changes: %v", required.Name, JSONPatchNoError(existingCopy, requiredCopy))
 	}
 
@@ -180,7 +180,7 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 		return existing, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/volumesnapshotclass.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/volumesnapshotclass.go
@@ -101,7 +101,7 @@ func ApplyVolumeSnapshotClass(ctx context.Context, client dynamic.Interface, rec
 		return existing, false, nil
 	}
 
-	if klog.V(4).Enabled() {
+	if klog.V(2).Enabled() {
 		klog.Infof("VolumeSnapshotClass %q changes: %v", required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/config.go
@@ -1,0 +1,58 @@
+package resourceread
+
+import (
+	"encoding/json"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	configScheme = runtime.NewScheme()
+	configCodecs = serializer.NewCodecFactory(configScheme)
+)
+
+func init() {
+	utilruntime.Must(configv1.AddToScheme(configScheme))
+}
+
+func ReadFeatureGateV1(objBytes []byte) (*configv1.FeatureGate, error) {
+	requiredObj, err := runtime.Decode(configCodecs.UniversalDecoder(configv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return requiredObj.(*configv1.FeatureGate), nil
+}
+
+func ReadFeatureGateV1OrDie(objBytes []byte) *configv1.FeatureGate {
+	requiredObj, err := ReadFeatureGateV1(objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj
+}
+func WriteFeatureGateV1(obj *configv1.FeatureGate) (string, error) {
+	// done for pretty printing of JSON (technically also yaml)
+	asMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return "", err
+	}
+	ret, err := json.MarshalIndent(asMap, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(ret) + "\n", nil
+}
+
+func WriteFeatureGateV1OrDie(obj *configv1.FeatureGate) string {
+	ret, err := WriteFeatureGateV1(obj)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 )
 
-func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, jiraComponent, description string, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
 	certificates := []*x509.Certificate{}
 	for _, input := range inputConfigMaps {
 		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
@@ -62,8 +62,7 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 		ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
 			destinationConfigMap.Name,
 			destinationConfigMap.Namespace,
-			jiraComponent,
-			description,
+			additionalAnnotations,
 		),
 		Data: map[string]string{
 			"ca-bundle.crt": string(caBytes),

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -585,9 +585,14 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	}
 
 	revisionStrings := []string{}
+	var nodesStr string
 	for _, currentRevision := range Int32KeySet(counts).List() {
 		count := counts[currentRevision]
-		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, currentRevision))
+		nodesStr = "node is"
+		if count > 1 {
+			nodesStr = "nodes are"
+		}
+		revisionStrings = append(revisionStrings, fmt.Sprintf("%d %s at revision %d", count, nodesStr, currentRevision))
 	}
 	// if we are progressing and no nodes have achieved that level, we should indicate
 	if numProgressing > 0 && counts[newStatus.LatestAvailableRevision] == 0 {

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,11 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
-
-	"github.com/ghodss/yaml"
-
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 // SetOperandVersion sets the new version and returns the previous value.
@@ -159,11 +159,31 @@ type UpdateStatusFunc func(status *operatorv1.OperatorStatus) error
 func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error) {
 	updated := false
 	var updatedOperatorStatus *operatorv1.OperatorStatus
+	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		_, oldStatus, resourceVersion, err := client.GetOperatorState()
+		defer func() {
+			numberOfAttempts++
+		}()
+		var oldStatus *operatorv1.OperatorStatus
+		var resourceVersion string
+		var err error
+
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -177,6 +197,9 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(4).Enabled() {
+			klog.Infof("Operator status changed: %v", operatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -184,6 +207,17 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func operatorStatusJSONPatchNoError(original, modified *operatorv1.OperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+
+	return cmp.Diff(original, modified)
 }
 
 // UpdateConditionFn returns a func to update a condition.
@@ -201,11 +235,31 @@ type UpdateStaticPodStatusFunc func(status *operatorv1.StaticPodOperatorStatus) 
 func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, updateFuncs ...UpdateStaticPodStatusFunc) (*operatorv1.StaticPodOperatorStatus, bool, error) {
 	updated := false
 	var updatedOperatorStatus *operatorv1.StaticPodOperatorStatus
+	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		_, oldStatus, resourceVersion, err := client.GetStaticPodOperatorState()
+		defer func() {
+			numberOfAttempts++
+		}()
+		var oldStatus *operatorv1.StaticPodOperatorStatus
+		var resourceVersion string
+		var err error
+
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -219,6 +273,9 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(4).Enabled() {
+			klog.Infof("Operator status changed: %v", staticPodOperatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -226,6 +283,16 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func staticPodOperatorStatusJSONPatchNoError(original, modified *operatorv1.StaticPodOperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+	return cmp.Diff(original, modified)
 }
 
 // UpdateStaticPodConditionFn returns a func to update a condition.

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/interfaces.go
@@ -14,6 +14,8 @@ type OperatorClient interface {
 	GetObjectMeta() (meta *metav1.ObjectMeta, err error)
 	// GetOperatorState returns the operator spec, status and the resource version, potentially from a lister.
 	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
+	// GetOperatorStateWithQuorum return the operator spec, status and resource version directly from a server read.
+	GetOperatorStateWithQuorum(ctx context.Context) (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
 	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource version.
 	UpdateOperatorSpec(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
 	// UpdateOperatorStatus updates the status of the operator, assuming the given resource version.

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
@@ -111,6 +111,10 @@ func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1.S
 	return c.fakeStaticPodOperatorSpec, c.fakeStaticPodOperatorStatus, c.resourceVersion, nil
 }
 
+func (c *fakeStaticPodOperatorClient) GetLiveStaticPodOperatorState() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
+	return c.GetStaticPodOperatorState()
+}
+
 func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum(ctx context.Context) (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
 	return c.fakeStaticPodOperatorSpec, c.fakeStaticPodOperatorStatus, c.resourceVersion, nil
 }
@@ -153,6 +157,9 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Co
 
 func (c *fakeStaticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return &c.fakeStaticPodOperatorSpec.OperatorSpec, &c.fakeStaticPodOperatorStatus.OperatorStatus, c.resourceVersion, nil
+}
+func (c *fakeStaticPodOperatorClient) GetOperatorStateWithQuorum(ctx context.Context) (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
+	return c.GetOperatorState()
 }
 func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(ctx context.Context, s string, p *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	panic("not supported")
@@ -239,6 +246,10 @@ func (c *fakeOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
 
 func (c *fakeOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return c.fakeOperatorSpec, c.fakeOperatorStatus, c.resourceVersion, nil
+}
+
+func (c *fakeOperatorClient) GetOperatorStateWithQuorum(ctx context.Context) (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
+	return c.GetOperatorState()
 }
 
 func (c *fakeOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {

--- a/vendor/github.com/openshift/library-go/test/library/metrics/query.go
+++ b/vendor/github.com/openshift/library-go/test/library/metrics/query.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/client-go/transport"
 )
 
+const prometheusServiceAccountName = "prometheus-k8s"
+
 // NewPrometheusClient returns Prometheus API or error
 // Note: with thanos-querier you must pass an entire Alert as a query. Partial queries return an error, so have to pass the entire alert.
 // Example query for an Alert:
@@ -28,29 +30,31 @@ import (
 func NewPrometheusClient(ctx context.Context, kclient kubernetes.Interface, rc routeclient.Interface) (prometheusv1.API, error) {
 	_, err := kclient.CoreV1().Services("openshift-monitoring").Get(ctx, "prometheus-k8s", metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get prometheus-k8s service: %w", err)
 	}
 
 	route, err := rc.RouteV1().Routes("openshift-monitoring").Get(ctx, "thanos-querier", metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get thanos-querier route: %w", err)
 	}
 	host := route.Status.Ingress[0].Host
+
 	var bearerToken string
 	secrets, err := kclient.CoreV1().Secrets("openshift-monitoring").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not list secrets in openshift-monitoring namespace")
+		return nil, fmt.Errorf("failed to list secrets in the openshift-monitoring namespace: %w", err)
 	}
+
 	for _, s := range secrets.Items {
 		if s.Type != corev1.SecretTypeServiceAccountToken ||
-			!strings.HasPrefix(s.Name, "prometheus-k8s") {
+			!strings.HasPrefix(s.Name, prometheusServiceAccountName) {
 			continue
 		}
 		bearerToken = string(s.Data[corev1.ServiceAccountTokenKey])
 		break
 	}
 	if len(bearerToken) == 0 {
-		return nil, fmt.Errorf("prometheus service account not found")
+		return nil, fmt.Errorf("%q service account not found", prometheusServiceAccountName)
 	}
 
 	return createClient(ctx, kclient, host, bearerToken)
@@ -60,7 +64,7 @@ func createClient(ctx context.Context, kclient kubernetes.Interface, host, beare
 	// retrieve router CA
 	routerCAConfigMap, err := kclient.CoreV1().ConfigMaps("openshift-config-managed").Get(ctx, "default-ingress-cert", metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get route CA: %w", err)
 	}
 	bundlePEM := []byte(routerCAConfigMap.Data["ca-bundle.crt"])
 
@@ -88,7 +92,8 @@ func createClient(ctx context.Context, kclient kubernetes.Interface, host, beare
 		),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create Prometheus API client: %w", err)
 	}
+
 	return prometheusv1.NewAPI(client), nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20240108202620-5674ec6ced1c
+# github.com/openshift/library-go v0.0.0-20240228143125-4602d24d27bc
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Library go no longer requires feature gates for observing cloud provider state. This PR updates library go to remove the reliance, and ensures that feature gate access is no longer being passed into the cloud provider observers.

A follow up to this is needed to make sure that the `--cloud-provider`, `--external-cloud-volume-plugin` and `--cloud-config` flags are cleared now they are no longer required, will add that as a separate PR later.