### PR TITLE
OCPBUGS-31807: use RotatedSigningCASecret and RotatedSelfSignedCertKeySecret only in update mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20231129134630-a782d1c1541c
 	github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c
 	github.com/openshift/client-go v0.0.0-20231005121823-e81400b97c46
-	github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4
+	github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c h1:H5
 github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20231005121823-e81400b97c46 h1:J7UsTNgyM1krYnfsmijowYqt5I4mDM1qxNAy4eEa0xc=
 github.com/openshift/client-go v0.0.0-20231005121823-e81400b97c46/go.mod h1:xM64ClnmCheAmffZZdTSJejy3yPE1nTRWQthKaZQ7JY=
-github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4 h1:1iObai4zzg+ZZYFJcyz68DSqezMZvCPg8YR71kPkYsQ=
-github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
+github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95 h1:7fzNW/fn2vID+h5IWNmueWCmjwNF/obnjIXhI/vHgfY=
+github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -95,6 +95,7 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 secretsGetter,
 			EventRecorder:          eventRecorder,
+			UseSecretUpdateOnly:    true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -119,10 +120,11 @@ func newCertRotationController(
 			CertCreator: &certrotation.SignerRotation{
 				SignerName: "kube-csr-signer",
 			},
-			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
-			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:        secretsGetter,
-			EventRecorder: eventRecorder,
+			Informer:            kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+			Lister:              kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+			Client:              secretsGetter,
+			EventRecorder:       eventRecorder,
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -52,6 +52,12 @@ type RotatedSigningCASecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
 func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
@@ -72,10 +78,15 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +101,7 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -68,6 +68,12 @@ type RotatedSelfSignedCertKeySecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
 type TargetCertCreator interface {
@@ -107,10 +113,15 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}
@@ -125,7 +136,7 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -84,7 +84,15 @@ func ApplyConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, r
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
-	return ApplySecretImproved(ctx, client, recorder, required, noCache)
+	return applySecretImproved(ctx, client, recorder, required, noCache, false)
+}
+
+// ApplySecretDoNotUse is depreated and will be removed
+// Deprecated: DO NOT USE, it is intended as a short term hack for a very specific use case,
+// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+// Use ApplySecret instead.
+func ApplySecretDoNotUse(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, required, noCache, true)
 }
 
 // ApplyNamespace merges objectmeta, does not worry about anything else
@@ -347,6 +355,10 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, requiredInput, cache, false)
+}
+
+func applySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache, updateOnly bool) (*corev1.Secret, bool, error) {
 	// copy the stringData to data.  Error on a data content conflict inside required.  This is usually a bug.
 
 	existing, err := client.Secrets(requiredInput.Namespace).Get(ctx, requiredInput.Name, metav1.GetOptions{})
@@ -426,6 +438,12 @@ func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter,
 	 * https://github.com/kubernetes/kubernetes/blob/98e65951dccfd40d3b4f31949c2ab8df5912d93e/pkg/apis/core/validation/validation.go#L5048
 	 * We need to explicitly opt for delete+create in that case.
 	 */
+	if updateOnly {
+		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, existingCopy, err)
+		return actual, err == nil, err
+	}
+
 	if existingCopy.Type == existing.Type {
 		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 		reportUpdateEvent(recorder, existingCopy, err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,7 +302,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4
+# github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
UseSecretUpdateOnly is intended as a short term hack for a very specific use case,
and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
(https://github.com/openshift/kubernetes/pull/1924)

we will remove this when we migrate all of the affected secret
objects to their intended type: https://issues.redhat.com/browse/API-1800

in short tls secrets used by this operator are reconciled
by multiple controllers ([the cert controller run by the operator](https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/pkg/operator/certrotationcontroller/certrotationcontroller.go#L85) and [the same controller run by the recovery pod](https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/pkg/cmd/recoverycontroller/cmd.go#L92)) at the same time without any coordination.

the issue is that the secret's crypto material
can be regenerated, which has serious consequences for the platform
as it can break external clients and the cluster itself.

xref: https://github.com/openshift/library-go/pull/1710
xref: https://github.com/openshift/kubernetes/pull/1939