### PR TITLE
API-1800: bindata: convert SecretTypeTLS secrets

### DIFF
--- a/bindata/bootkube/manifests/secret-csr-signer-signer.yaml
+++ b/bindata/bootkube/manifests/secret-csr-signer-signer.yaml
@@ -7,7 +7,7 @@ metadata:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "kubelet-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kubelet-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kubelet-signer.crt" | issuer }}
-type: SecretTypeTLS
+type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kubelet-signer.crt" | base64 }}
   tls.key: {{ .Assets | load "kubelet-signer.key" | base64 }}


### PR DESCRIPTION
SecretTypeTLS is a deprecated type, which gets converted to kubernetes.io/tls when controller parses. Changing this type to supported to make controller skip convertion on initial install.