### PR TITLE
Update PodDisruptionBudgetAtLimit alert

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml
@@ -28,7 +28,7 @@ spec:
             description: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods.
             runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
           expr: |
-            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy and on (namespace, poddisruptionbudget) kube_poddisruptionbudget_status_expected_pods > 0)
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy{poddisruptionbudget!~'kubevirt-disruption-budget-.*'} == kube_poddisruptionbudget_status_desired_healthy{poddisruptionbudget!~'kubevirt-disruption-budget-.*'} and on (namespace, poddisruptionbudget) kube_poddisruptionbudget_status_expected_pods{poddisruptionbudget!~'kubevirt-disruption-budget-.*'} > 0)
           for: 60m
           labels:
             severity: warning


### PR DESCRIPTION
Update the PodDisruptionBudgetAtLimit  alert to not fire for
kubevirt-disruption-budge, since they are not needed in this use case.

This PR is very important since the alerts fire for every namespace that is running VM, even tough it is not needed and is causing an alert fatigue.

Jira-url: https://issues.redhat.com/browse/CNV-33834

Signed-off-by: Shirly Radco <sradco@redhat.com>
