### PR TITLE
OCPBUGS-34859: manifests: set owning-component for csr-signer-signer

### DIFF
--- a/bindata/bootkube/manifests/secret-csr-signer-signer.yaml
+++ b/bindata/bootkube/manifests/secret-csr-signer-signer.yaml
@@ -7,6 +7,7 @@ metadata:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "kubelet-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kubelet-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kubelet-signer.crt" | issuer }}
+    "openshift.io/owning-component": "kube-controller-manager"
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kubelet-signer.crt" | base64 }}


### PR DESCRIPTION
Ensure that the secret has necessary annotations applied on creation time, so that the controller didn't have to wait for changes in the secret to apply ownership annotations. This fixes a regression after https://github.com/openshift/cluster-kube-controller-manager-operator/pull/804