### PR TITLE
OCPBUGS-34281: Updating ose-cluster-kube-controller-manager-operator-container image to be consistent with ART for 4.17

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-kube-controller-manager-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 RUN mkdir -p /usr/share/bootkube/manifests/bootstrap-manifests/ /usr/share/bootkube/manifests/config/ /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-controller-manager-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-controller-manager-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/cluster-kube-controller-manager-operator
 
-go 1.22.0
-
-toolchain go1.22.1
+go 1.22.1
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Extending #809 