### PR TITLE
NO-ISSUE: Bump TraceAll log level to v=10

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -537,7 +537,7 @@ func managePod(ctx context.Context, configMapsGetter corev1client.ConfigMapsGett
 	case operatorv1.Trace:
 		logLevel = 6
 	case operatorv1.TraceAll:
-		logLevel = 8
+		logLevel = 10
 	default:
 		logLevel = 2
 	}


### PR DESCRIPTION
- and the kube-scheduler-operator has already set the TraceAll to 10, as seen in https://github.com/openshift/cluster-kube-scheduler-operator/blame/b1cc4471e2f6c5dc81b2b9471f4634f1ecdb88b4/pkg/operator/targetconfigcontroller/targetconfigcontroller.go#L267

- and the microshift has also bump this TraceAll loglevel to 10  https://github.com/openshift/microshift/pull/4400

If we use TraceALL, we want to trace all the logs really, and some important k8s logs are v(10)