### PR TITLE
OCPBUGS-53290: Missing endpoint slices for open ports the operator uses

### DIFF
--- a/bindata/assets/config/default-cluster-policy-controller-config.yaml
+++ b/bindata/assets/config/default-cluster-policy-controller-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: openshiftcontrolplane.config.openshift.io/v1
 kind: OpenShiftControllerManagerConfig
 servingInfo:
-  bindAddress: 0.0.0.0:10357
+  bindAddress: 127.0.0.1:10357
   bindNetwork: tcp
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt

--- a/bindata/assets/kube-controller-manager/pod.yaml
+++ b/bindata/assets/kube-controller-manager/pod.yaml
@@ -106,6 +106,7 @@ spec:
         scheme: HTTPS
         port: 10357
         path: healthz
+        host: localhost
       initialDelaySeconds: 0
       timeoutSeconds: 3
     livenessProbe:
@@ -113,6 +114,7 @@ spec:
         scheme: HTTPS
         port: 10357
         path: healthz
+        host: localhost
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
@@ -120,6 +122,7 @@ spec:
         scheme: HTTPS
         port: 10357
         path: healthz
+        host: localhost
       initialDelaySeconds: 10
       timeoutSeconds: 10
   - name: kube-controller-manager-cert-syncer

--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -107,6 +107,7 @@ spec:
         scheme: HTTPS
         port: 10357
         path: healthz
+        host: localhost
       initialDelaySeconds: 0
       timeoutSeconds: 3
     livenessProbe:
@@ -114,6 +115,7 @@ spec:
         scheme: HTTPS
         port: 10357
         path: healthz
+        host: localhost
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:
@@ -121,6 +123,7 @@ spec:
         scheme: HTTPS
         port: 10357
         path: healthz
+        host: localhost
       initialDelaySeconds: 10
       timeoutSeconds: 10
   volumes:


### PR DESCRIPTION
Port 10357 (cluster-policy-controller) was missing service exposure. 

## Problem

The cluster-policy-controller runs on port 10357 within the kube-controller-manager pod but was not exposed through the service. This caused missing endpoint slices for the port that the operator uses.

so the port dont need to be exposed and it need to be internal  with local host
