### PR TITLE
NO-JIRA: targetconfigcontroller: set description for csr-controller-ca

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -710,6 +710,7 @@ func ManageCSRCABundle(ctx context.Context, lister corev1listers.ConfigMapLister
 		lister,
 		certrotation.AdditionalAnnotations{
 			JiraComponent: "kube-controller-manager",
+			Description:   "CA to recognize the CSRs (both serving and client) signed by the kube-controller-manager.",
 		},
 		// include the CA we use to sign CSRs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-signer-ca"},


### PR DESCRIPTION
Ensure CA description is set to match CKAO managed configmap: https://github.com/openshift/cluster-kube-apiserver-operator/blob/main/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml#L9C34-L9C123