### PR TITLE
OCPBUGS-60473: Optimistically update Kube Server and Client CA bundles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
-	github.com/openshift/library-go v0.0.0-20250710130336-73c7662bc565
+	github.com/openshift/library-go v0.0.0-20250812160438-378de074fe7b
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.62.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8hK3eEsHqxsXurq/D6LcINGfprkQC3hqY=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
-github.com/openshift/library-go v0.0.0-20250710130336-73c7662bc565 h1:DtyzonCpVZxqYp4rp2cCRwBTEXZWw5fX9YE0tCM5hi8=
-github.com/openshift/library-go v0.0.0-20250710130336-73c7662bc565/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
+github.com/openshift/library-go v0.0.0-20250812160438-378de074fe7b h1:AvoeP4LZgeHXTeNO7HiSdIxPbYrKvpJFa1JNTiYrx8M=
+github.com/openshift/library-go v0.0.0-20250812160438-378de074fe7b/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -107,10 +107,11 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-controller-manager",
 			},
-			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
-			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:        configMapsGetter,
-			EventRecorder: eventRecorder,
+			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
+			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
+			Client:                 configMapsGetter,
+			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
 			Namespace: operatorclient.OperatorNamespace,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -54,7 +54,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	if err != nil {
 		return err
 	}
-
+	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
 	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient,
 		"",
@@ -199,7 +199,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	}
 	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
 
-	staticPodControllers, err := staticpod.NewBuilder(operatorClient, kubeClient, kubeInformersForNamespaces, configInformers, cc.Clock).
+	staticPodControllers, err := staticpod.NewBuilder(operatorClient, kubeClient, kubeInformersForNamespaces, clusterInformers.InformersFor(""), configInformers, cc.Clock).
 		WithEvents(cc.EventRecorder).
 		WithInstaller([]string{"cluster-kube-controller-manager-operator", "installer"}).
 		WithPruning([]string{"cluster-kube-controller-manager-operator", "prune"}, "kube-controller-manager-pod").
@@ -287,6 +287,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	})
 
 	configInformers.Start(ctx.Done())
+	clusterInformers.Start(ctx.Done())
 	kubeInformersForNamespaces.Start(ctx.Done())
 	dynamicInformers.Start(ctx.Done())
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -686,12 +687,32 @@ func GetKubeControllerManagerArgs(config map[string]interface{}) []string {
 }
 
 func manageServiceAccountCABundle(ctx context.Context, lister corev1listers.ConfigMapLister, client corev1client.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
-	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "serviceaccount-ca"},
+	additionalAnnotations := certrotation.AdditionalAnnotations{
+		JiraComponent: "kube-controller-manager",
+	}
+	caBundleConfigMapName := "serviceaccount-ca"
+
+	creationRequired := false
+	updateRequired := false
+
+	caBundleConfigMap, err := lister.ConfigMaps(operatorclient.TargetNamespace).Get(caBundleConfigMapName)
+	switch {
+	case apierrors.IsNotFound(err):
+		creationRequired = true
+		caBundleConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caBundleConfigMapName,
+				Namespace: operatorclient.TargetNamespace,
+			},
+		}
+	case err != nil:
+		return nil, false, err
+	}
+
+	requiredConfigMap, updateRequired, err := resourcesynccontroller.CombineCABundleConfigMapsOptimistically(
+		caBundleConfigMap,
 		lister,
-		certrotation.AdditionalAnnotations{
-			JiraComponent: "kube-controller-manager",
-		},
+		additionalAnnotations,
 		// include the ca bundle needed to recognize the server
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-server-ca"},
 		// include the ca bundle needed to recognize default
@@ -701,17 +722,56 @@ func manageServiceAccountCABundle(ctx context.Context, lister corev1listers.Conf
 	if err != nil {
 		return nil, false, err
 	}
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+
+	if creationRequired {
+		caBundleConfigMap, err = client.ConfigMaps(operatorclient.TargetNamespace).Create(ctx, requiredConfigMap, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Created serviceaccount CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	} else if updateRequired {
+		caBundleConfigMap, err = client.ConfigMaps(operatorclient.TargetNamespace).Update(ctx, requiredConfigMap, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Updated serviceaccount CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	}
+
+	return caBundleConfigMap, false, nil
 }
 
 func ManageCSRCABundle(ctx context.Context, lister corev1listers.ConfigMapLister, client corev1client.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
-	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-controller-ca"},
+	additionalAnnotations := certrotation.AdditionalAnnotations{
+		JiraComponent: "kube-controller-manager",
+		Description:   "CA to recognize the CSRs (both serving and client) signed by the kube-controller-manager.",
+	}
+	caBundleConfigMapName := "csr-controller-ca"
+
+	creationRequired := false
+	updateRequired := false
+
+	caBundleConfigMap, err := lister.ConfigMaps(operatorclient.OperatorNamespace).Get(caBundleConfigMapName)
+	switch {
+	case apierrors.IsNotFound(err):
+		creationRequired = true
+		caBundleConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caBundleConfigMapName,
+				Namespace: operatorclient.OperatorNamespace,
+			},
+		}
+	case err != nil:
+		return nil, false, err
+	}
+
+	requiredConfigMap, updateRequired, err := resourcesynccontroller.CombineCABundleConfigMapsOptimistically(
+		caBundleConfigMap,
 		lister,
-		certrotation.AdditionalAnnotations{
-			JiraComponent: "kube-controller-manager",
-			Description:   "CA to recognize the CSRs (both serving and client) signed by the kube-controller-manager.",
-		},
+		additionalAnnotations,
 		// include the CA we use to sign CSRs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "csr-signer-ca"},
 		// include the CA we use to sign the cert key pairs from from csr-signer
@@ -720,7 +780,25 @@ func ManageCSRCABundle(ctx context.Context, lister corev1listers.ConfigMapLister
 	if err != nil {
 		return nil, false, err
 	}
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+	if creationRequired {
+		caBundleConfigMap, err = client.ConfigMaps(operatorclient.OperatorNamespace).Create(ctx, requiredConfigMap, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Created CSR CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	} else if updateRequired {
+		caBundleConfigMap, err = client.ConfigMaps(operatorclient.OperatorNamespace).Update(ctx, requiredConfigMap, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Updated CSR CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	}
+
+	return caBundleConfigMap, false, nil
 }
 
 func ManageCSRSigner(ctx context.Context, lister corev1listers.SecretLister, client corev1client.SecretsGetter, recorder events.Recorder) (*corev1.Secret, time.Duration, bool, error) {

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -629,7 +629,7 @@ func MakeSelfSignedCAConfig(name string, lifetime time.Duration) (*TLSCertificat
 func MakeSelfSignedCAConfigForSubject(subject pkix.Name, lifetime time.Duration) (*TLSCertificateConfig, error) {
 	if lifetime <= 0 {
 		lifetime = DefaultCACertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCACertificateLifetimeDuration {
@@ -1018,7 +1018,7 @@ func newSigningCertificateTemplateForDuration(subject pkix.Name, caLifetime time
 func newServerCertificateTemplate(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
 	if lifetime <= 0 {
 		lifetime = DefaultCertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCertificateLifetimeDuration {
@@ -1105,7 +1105,7 @@ func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
 func NewClientCertificateTemplate(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
 	if lifetime <= 0 {
 		lifetime = DefaultCertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCertificateLifetimeDuration {

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -16,9 +16,13 @@ const (
 	CertificateIssuer = "auth.openshift.io/certificate-issuer"
 	// CertificateHostnames contains the hostnames used by a signer.
 	CertificateHostnames = "auth.openshift.io/certificate-hostnames"
-	// AutoRegenerateAfterOfflineExpiryAnnotation contains a link to PR and an e2e test name which verifies
+	// CertificateTestNameAnnotation is an e2e test name which verifies that TLS artifact is created and used correctly
+	CertificateTestNameAnnotation string = "certificates.openshift.io/test-name"
+	// CertificateAutoRegenerateAfterOfflineExpiryAnnotation contains a link to PR adding this annotation which verifies
 	// that TLS artifact is correctly regenerated after it has expired
-	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+	CertificateAutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+	// CertificateRefreshPeriodAnnotation is the interval at which the certificate should be refreshed.
+	CertificateRefreshPeriodAnnotation string = "certificates.openshift.io/refresh-period"
 )
 
 type AdditionalAnnotations struct {
@@ -26,13 +30,16 @@ type AdditionalAnnotations struct {
 	JiraComponent string
 	// Description is a human-readable one sentence description of certificate purpose
 	Description string
-	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
-	// that TLS artifact is correctly regenerated after it has expired
+	// TestName is an e2e test name which verifies that TLS artifact is created and used correctly
+	TestName string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR which adds this annotation on the TLS artifact
 	AutoRegenerateAfterOfflineExpiry string
 	// NotBefore contains certificate the certificate creation date in RFC3339 format.
 	NotBefore string
 	// NotAfter contains certificate the certificate validity date in RFC3339 format.
 	NotAfter string
+	// RefreshPeriod contains the interval at which the certificate should be refreshed.
+	RefreshPeriod string
 }
 
 func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
@@ -42,28 +49,44 @@ func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) 
 	}
 	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
 		diff := cmp.Diff(meta.Annotations[annotations.OpenShiftComponent], a.JiraComponent)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftComponent, meta.Name, meta.Namespace, diff)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftComponent, meta.Namespace, meta.Name, diff)
 		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
 		modified = true
 	}
 	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
 		diff := cmp.Diff(meta.Annotations[annotations.OpenShiftDescription], a.Description)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftDescription, meta.Name, meta.Namespace, diff)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftDescription, meta.Namespace, meta.Name, diff)
 		meta.Annotations[annotations.OpenShiftDescription] = a.Description
 		modified = true
 	}
-	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
-		diff := cmp.Diff(meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation], a.AutoRegenerateAfterOfflineExpiry)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", AutoRegenerateAfterOfflineExpiryAnnotation, meta.Name, meta.Namespace, diff)
-		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
+	if len(a.TestName) > 0 && meta.Annotations[CertificateTestNameAnnotation] != a.TestName {
+		diff := cmp.Diff(meta.Annotations[CertificateTestNameAnnotation], a.TestName)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateTestNameAnnotation, meta.Name, meta.Namespace, diff)
+		meta.Annotations[CertificateTestNameAnnotation] = a.TestName
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		diff := cmp.Diff(meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation], a.AutoRegenerateAfterOfflineExpiry)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateAutoRegenerateAfterOfflineExpiryAnnotation, meta.Namespace, meta.Name, diff)
+		meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
 		modified = true
 	}
 	if len(a.NotBefore) > 0 && meta.Annotations[CertificateNotBeforeAnnotation] != a.NotBefore {
+		diff := cmp.Diff(meta.Annotations[CertificateNotBeforeAnnotation], a.NotBefore)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateNotBeforeAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateNotBeforeAnnotation] = a.NotBefore
 		modified = true
 	}
 	if len(a.NotAfter) > 0 && meta.Annotations[CertificateNotAfterAnnotation] != a.NotAfter {
+		diff := cmp.Diff(meta.Annotations[CertificateNotAfterAnnotation], a.NotAfter)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateNotAfterAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateNotAfterAnnotation] = a.NotAfter
+		modified = true
+	}
+	if len(a.RefreshPeriod) > 0 && meta.Annotations[CertificateRefreshPeriodAnnotation] != a.RefreshPeriod {
+		diff := cmp.Diff(meta.Annotations[CertificateRefreshPeriodAnnotation], a.RefreshPeriod)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateRefreshPeriodAnnotation, meta.Name, meta.Namespace, diff)
+		meta.Annotations[CertificateRefreshPeriodAnnotation] = a.RefreshPeriod
 		modified = true
 	}
 	return modified

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/metadata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/metadata.go
@@ -5,7 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ensureMetadataUpdate(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) bool {
+func ensureOwnerRefAndTLSAnnotations(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) bool {
 	needsMetadataUpdate := false
 	// no ownerReference set
 	if owner != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -114,14 +114,14 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 	// run Update if metadata needs changing unless we're in RefreshOnlyWhenExpired mode
 	if !c.RefreshOnlyWhenExpired {
-		needsMetadataUpdate := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+		needsMetadataUpdate := ensureOwnerRefAndTLSAnnotations(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
 		needsTypeChange := ensureSecretTLSTypeSet(targetCertKeyPairSecret)
 		updateRequired = needsMetadataUpdate || needsTypeChange
 	}
 
 	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired, creationRequired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
-		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+		if err = setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret, c.Validity, c.Refresh, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
 			return nil, err
 		}
 
@@ -232,9 +232,21 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 	return ""
 }
 
+// setTargetCertKeyPairSecretAndTLSAnnotations generates a new cert/key pair,
+// stores them in the specified secret, and adds predefined TLS annotations to that secret.
+func setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, signer *crypto.CA, certCreator TargetCertCreator, tlsAnnotations AdditionalAnnotations) error {
+	certKeyPair, err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, validity, signer, certCreator)
+	if err != nil {
+		return err
+	}
+
+	setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret, certKeyPair, certCreator, refresh, tlsAnnotations)
+	return nil
+}
+
 // setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret.  Only one of client, serving, or signer rotation may be specified.
 // TODO refactor with an interface for actually signing and move the one-of check higher in the stack.
-func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, annotations AdditionalAnnotations) error {
+func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator) (*crypto.TLSCertificateConfig, error) {
 	if targetCertKeyPairSecret.Annotations == nil {
 		targetCertKeyPairSecret.Annotations = map[string]string{}
 	}
@@ -251,21 +263,29 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 
 	certKeyPair, err := certCreator.NewCertificate(signer, targetValidity)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	targetCertKeyPairSecret.Data["tls.crt"], targetCertKeyPairSecret.Data["tls.key"], err = certKeyPair.GetPEMBytes()
-	if err != nil {
-		return err
-	}
-	annotations.NotBefore = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
-	annotations.NotAfter = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
+	return certKeyPair, err
+}
+
+// setTLSAnnotationsOnTargetCertKeyPairSecret applies predefined TLS annotations to the given secret.
+//
+// This function does not perform nil checks on its parameters and assumes that the
+// secret's Annotations field has already been initialized.
+//
+// These assumptions are safe because this function is only called after the secret
+// has been initialized in setTargetCertKeyPairSecret.
+func setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig, certCreator TargetCertCreator, refresh time.Duration, tlsAnnotations AdditionalAnnotations) {
 	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
 
-	_ = annotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
-	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
+	tlsAnnotations.NotBefore = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
+	tlsAnnotations.NotAfter = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
+	tlsAnnotations.RefreshPeriod = refresh.String()
+	_ = tlsAnnotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
 
-	return nil
+	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
 }
 
 type ClientRotation struct {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -70,3 +70,64 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 	}
 	return cm, nil
 }
+
+func CombineCABundleConfigMapsOptimistically(destinationConfigMap *corev1.ConfigMap, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, bool, error) {
+	var cm *corev1.ConfigMap
+	if destinationConfigMap == nil {
+		cm = &corev1.ConfigMap{}
+	} else {
+		cm = destinationConfigMap.DeepCopy()
+	}
+	certificates := []*x509.Certificate{}
+	for _, input := range inputConfigMaps {
+		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, false, err
+		}
+
+		// configmaps must conform to this
+		inputContent := inputConfigMap.Data["ca-bundle.crt"]
+		if len(inputContent) == 0 {
+			continue
+		}
+		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))
+		if err != nil {
+			return nil, false, fmt.Errorf("configmap/%s in %q is malformed: %v", input.Name, input.Namespace, err)
+		}
+		certificates = append(certificates, inputCerts...)
+	}
+
+	certificates = crypto.FilterExpiredCerts(certificates...)
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := additionalAnnotations.EnsureTLSMetadataUpdate(&cm.ObjectMeta)
+	newCMData := map[string]string{
+		"ca-bundle.crt": string(caBytes),
+	}
+	if !reflect.DeepEqual(cm.Data, newCMData) {
+		cm.Data = newCMData
+		modified = true
+	}
+	return cm, modified, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
@@ -2,22 +2,21 @@ package status
 
 import (
 	"context"
-	"k8s.io/utils/clock"
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	configv1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -29,6 +28,8 @@ import (
 type VersionGetter interface {
 	// SetVersion is a way to set the version for an operand.  It must be thread-safe
 	SetVersion(operandName, version string)
+	// UnsetVersion removes a version for an operand if it exists; it is a no-op otherwise.  It must be thread-safe
+	UnsetVersion(operandName string)
 	// GetVersion is way to get the versions for all operands.  It must be thread-safe and return an object that doesn't mutate
 	GetVersions() map[string]string
 	// VersionChangedChannel is a channel that will get an item whenever SetVersion has been called

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
@@ -35,14 +35,19 @@ func (v *versionGetter) SetVersion(operandName, version string) {
 	defer v.lock.Unlock()
 
 	v.versions[operandName] = version
+	v.notifyChannelsLocked()
+}
 
-	for i := range v.notificationChannels {
-		ch := v.notificationChannels[i]
-		// don't let a slow consumer block the rest
-		go func() {
-			ch <- struct{}{}
-		}()
+func (v *versionGetter) UnsetVersion(operandName string) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	if _, exists := v.versions[operandName]; !exists {
+		return
 	}
+
+	delete(v.versions, operandName)
+	v.notifyChannelsLocked()
 }
 
 func (v *versionGetter) GetVersions() map[string]string {
@@ -63,6 +68,17 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 	channel := make(chan struct{}, 50)
 	v.notificationChannels = append(v.notificationChannels, channel)
 	return channel
+}
+
+// notifyChannelsLocked must be called under a locked v.lock
+func (v *versionGetter) notifyChannelsLocked() {
+	for i := range v.notificationChannels {
+		ch := v.notificationChannels[i]
+		// don't let a slow consumer block the rest
+		go func() {
+			ch <- struct{}{}
+		}()
+	}
 }
 
 func ImageForOperandFromEnv() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -306,7 +306,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20250710130336-73c7662bc565
+# github.com/openshift/library-go v0.0.0-20250812160438-378de074fe7b
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
Instead of re-creating configmap from scratch every time this function should attempt to use existing configmap and replace the contents only. This would prevent extra configmap updates when metadata changes.

See similar PR in CKAO: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1812