### PR TITLE
RFE-4154: Remove readOnlyRootFilesystem from KCM container

### DIFF
--- a/bindata/assets/kube-controller-manager/pod.yaml
+++ b/bindata/assets/kube-controller-manager/pod.yaml
@@ -48,14 +48,6 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-    - mountPath: /tmp
-      name: tmp-dir
-    - mountPath: /etc/pki/ca-trust/extracted/pem
-      name: ca-trust-dir
-    - mountPath: /var/run/kubernetes
-      name: var-run-kubernetes
-    - mountPath: /etc/kubernetes/kubelet-plugins
-      name: kubelet-plugins
     startupProbe:
       httpGet:
         scheme: HTTPS
@@ -77,8 +69,6 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
-    securityContext:
-      readOnlyRootFilesystem: true
   - name: cluster-policy-controller
     env:
       - name: POD_NAME

--- a/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-controller-manager-pod.yaml
@@ -42,14 +42,6 @@ spec:
       readOnly: true
     - mountPath: /var/log/bootstrap-control-plane
       name: logs
-    - mountPath: /tmp
-      name: tmp
-    - mountPath: /etc/pki/ca-trust/extracted/pem
-      name: ca-trust
-    - mountPath: /var/run/kubernetes
-      name: var-run-kubernetes
-    securityContext:
-      readOnlyRootFilesystem: true
     startupProbe:
       httpGet:
         scheme: HTTPS


### PR DESCRIPTION
There are controllers that attempt to create /etc/kubernetes/kubelet-plugins which fail because of the readonly filesystem. This means that the KCM container cannot be readonly.

Not doing a revert as there are other containers in the KCM pod that could be read only root filesystem