### PR TITLE
Use BoundServceAccountTokenVolume dy default

### DIFF
--- a/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-controller-manager-operator_06_deployment.yaml
@@ -29,7 +29,6 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
-      automountServiceAccountToken: false
       serviceAccountName: kube-controller-manager-operator
       containers:
       - name: kube-controller-manager-operator
@@ -56,9 +55,6 @@ spec:
           name: config
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
-          readOnly: true
         - mountPath: /tmp
           name: tmp-dir
         env:
@@ -87,24 +83,6 @@ spec:
       - name: config
         configMap:
           name: kube-controller-manager-operator-config
-      - name: kube-api-access
-        projected:
-          defaultMode: 420
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3600
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace
       - name: tmp-dir
         emptyDir: {}
       nodeSelector:


### PR DESCRIPTION
The BoundServiceAccountTokenVolume is enabled by default

kind of post-cleanup of https://github.com/openshift/kubernetes/pull/714 and https://github.com/openshift/cluster-kube-controller-manager-operator/pull/531