### PR TITLE
CNTRLPLANE-1275: Add JUnit reporter configuration and README for OTE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 _output
 telepresence.log
 .openshift-tests-extension/openshift_payload_*.json
-report.json
-junit.xml
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 _output
 telepresence.log
 .openshift-tests-extension/openshift_payload_*.json
+report.json
+junit.xml

--- a/cmd/cluster-kube-controller-manager-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-controller-manager-operator-tests-ext/main.go
@@ -75,6 +75,10 @@ func runGinkgoTest(ctx context.Context, testName string) *extensiontests.Extensi
 	// Run the test suite with focus on specific test
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
 	suiteConfig.FocusStrings = []string{escapeRegexChars(testName)}
+	
+	// Configure JUnit reporter for CI integration
+	reporterConfig.JUnitReport = "junit.xml"
+	reporterConfig.JSONReport = "report.json"
 
 	passed := ginkgo.RunSpecs(NewGinkgoTestingT(), "OpenShift Kube Controller Manager Operator Test Suite", suiteConfig, reporterConfig)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/gonum/graph v0.0.0-20190426092945-678096d81a4b
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.22.1
+	github.com/onsi/gomega v1.36.1
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
@@ -24,11 +26,6 @@ require (
 	k8s.io/component-base v0.33.2
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
-)
-
-require (
-	github.com/onsi/gomega v1.36.1
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292
 )
 
 require (

--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -1,0 +1,156 @@
+# OpenShift Kube Controller Manager Operator Tests Extension
+========================================================
+
+This repository contains the tests for the OpenShift Kube Controller Manager Operator for OpenShift.
+These tests run against OpenShift clusters and are meant to be used in the OpenShift CI/CD pipeline.
+They use the framework: https://github.com/openshift-eng/openshift-tests-extension
+
+## How to Run the Tests Locally
+
+| Command | Description |
+|---------|-------------|
+| `make tests-ext-build` | Builds the test extension binary. |
+| `./cluster-kube-controller-manager-operator-tests-ext list` | Lists all available test cases. |
+| `./cluster-kube-controller-manager-operator-tests-ext run-suite <suite-name>` | Runs a test suite. e.g., `openshift/cluster-kube-controller-manager-operator/conformance/parallel` |
+| `./cluster-kube-controller-manager-operator-tests-ext run-test <test-name>` | Runs one specific test. |
+
+## How to Run the Tests Locally
+
+The tests can be run locally using the `cluster-kube-controller-manager-operator-tests-ext` binary against an OpenShift cluster.
+Use the environment variable `KUBECONFIG` to point to your cluster configuration file such as:
+
+```shell
+export KUBECONFIG=path/to/kubeconfig
+./cluster-kube-controller-manager-operator-tests-ext run-test <test-name>
+```
+
+### Local Test using OCP
+
+1. Use the `Cluster Bot` to create an OpenShift cluster.
+
+**Example:**
+```shell
+launch 4.20 gcp,techpreview
+```
+
+2. Set the `KUBECONFIG` environment variable to point to your OpenShift cluster configuration file.
+
+**Example:**
+```shell
+mv ~/Downloads/cluster-bot-2025-08-06-082741.kubeconfig ~/.kube/cluster-bot.kubeconfig
+export KUBECONFIG=~/.kube/cluster-bot.kubeconfig
+```
+
+3. Run the tests using the `cluster-kube-controller-manager-operator-tests-ext` binary.
+
+**Example:**
+```shell
+./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/all
+```
+
+### Running with JUnit Output
+
+To generate JUnit XML reports for CI integration:
+
+```shell
+./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/conformance/parallel --junit-path junit.xml
+```
+
+This generates both OTE framework and Ginkgo JUnit XML reports that can be integrated into CI systems.
+
+## Available Test Suites
+
+| Suite Name | Description |
+|------------|-------------|
+| `openshift/cluster-kube-controller-manager-operator/conformance/parallel` | Parallel conformance tests |
+| `openshift/cluster-kube-controller-manager-operator/conformance/serial` | Serial conformance tests |
+| `openshift/cluster-kube-controller-manager-operator/optional/slow` | Optional slow tests |
+| `openshift/cluster-kube-controller-manager-operator/all` | All tests |
+
+## CI/CD Integration
+
+The tests are integrated into the OpenShift CI/CD pipeline through the release configuration.
+The CI configuration runs the OTE binary and generates JUnit reports for test result tracking.
+
+**Example CI step:**
+```yaml
+- as: tests-extension
+  commands: |
+    echo "Build binary cluster-kube-controller-manager-operator-tests-ext"
+    make tests-ext-build
+    echo "Running ./cluster-kube-controller-manager-operator-tests-ext with sanity test"
+    ./cluster-kube-controller-manager-operator-tests-ext run-suite "openshift/cluster-kube-controller-manager-operator/conformance/parallel" --junit-path junit.xml
+  from: src
+  resources:
+    requests:
+      cpu: 100m
+```
+
+## Makefile Commands
+
+| Target | Description |
+|--------|-------------|
+| `make build` | Builds the operator binary. |
+| `make tests-ext-build` | Builds the test extension binary. |
+| `make tests-ext-update` | Updates the metadata JSON file and cleans machine-specific codeLocations. |
+| `make verify` | Runs formatting, vet, and linter. |
+
+**Note:** Metadata is stored in: `.openshift-tests-extension/cluster-kube-controller-manager-operator.json`
+
+## FAQ
+
+### Why don't we have a Dockerfile for `cluster-kube-controller-manager-operator-tests-ext`?
+
+We do not provide a Dockerfile for `cluster-kube-controller-manager-operator-tests-ext` because building and shipping a
+standalone image for this test binary would introduce unnecessary complexity.
+
+Technically, it is possible to create a new OpenShift component just for the
+tests and add a corresponding test image to the payload. However, doing so requires
+onboarding a new component, setting up build pipelines, and maintaining image promotion
+and test configuration — all of which adds overhead.
+
+From the OpenShift architecture point of view:
+
+1. Tests for payload components are part of the product. Many users (such as storage vendors, or third-party CNIs)
+rely on these tests to validate that their solutions are compatible and conformant with OpenShift.
+
+2. Adding new images to the payload comes with significant overhead and cost.
+It is generally preferred to include tests in the same image as the component
+being tested whenever possible.
+
+### Why do we need to run `make tests-ext-update`?
+
+Running `make tests-ext-update` ensures that each test gets a unique and stable **TestID** over time.
+
+The TestID is used to identify tests across the OpenShift CI/CD pipeline and reporting tools like Sippy.
+It helps track test results, detect regressions, and ensures the correct tests are
+executed and reported.
+
+This step is important whenever you add, rename, or delete a test.
+More information:
+- https://github.com/openshift/enhancements/blob/master/enhancements/testing/openshift-tests-extension.md#test-id
+- https://github.com/openshift-eng/ci-test-mapping
+
+### How to get help with OTE?
+
+For help with the OpenShift Tests Extension (OTE), you can reach out on the #wg-openshift-tests-extension Slack channel.
+
+## Test Implementation Details
+
+The OTE implementation uses the registry-based approach from the `openshift-tests-extension` framework:
+
+- **Registry Pattern**: Uses `extension.NewRegistry()` and `extension.NewExtension()` for clean, maintainable code
+- **JUnit Integration**: Generates both OTE framework and Ginkgo JUnit XML reports
+- **Test Discovery**: Automatically discovers and registers Ginkgo tests from the `test/extended` package
+- **CI Ready**: Includes proper JUnit reporter configuration for CI integration
+
+## Architecture
+
+The OTE binary (`cluster-kube-controller-manager-operator-tests-ext`) provides:
+
+1. **Test Discovery**: Lists all available tests and suites
+2. **Test Execution**: Runs individual tests or entire suites
+3. **Result Reporting**: Generates JSON and JUnit XML output
+4. **CI Integration**: Provides standardized output formats for CI systems
+
+The implementation follows OpenShift best practices and integrates seamlessly with the existing CI/CD pipeline.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/logging.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/logging.go
@@ -1,0 +1,21 @@
+package ginkgo
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/onsi/ginkgo/v2"
+)
+
+// this is copied from ginkgo because ginkgo made it internal and then hardcoded an init block
+// using these functions to wire to os.stdout and we want to wire to stderr (or a different buffer) so we can
+// have json output.
+
+func GinkgoLogrFunc(writer ginkgo.GinkgoWriterInterface) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		if prefix == "" {
+			writer.Printf("%s\n", args)
+		} else {
+			writer.Printf("%s %s\n", prefix, args)
+		}
+	}, funcr.Options{})
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/parallel.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/parallel.go
@@ -1,0 +1,139 @@
+package ginkgo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+)
+
+func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Duration) *extensiontests.ExtensionTestResult {
+	// longerCtx is used to backstop the process, but leave termination up to us if possible to allow a double interrupt
+	longerCtx, longerCancel := context.WithTimeout(ctx, timeout+15*time.Minute)
+	defer longerCancel()
+	timeoutCtx, shorterCancel := context.WithTimeout(longerCtx, timeout)
+	defer shorterCancel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	command := exec.CommandContext(longerCtx, os.Args[0], "run-test", "--output=json", testName)
+	command.Stdout = stdout
+	command.Stderr = stderr
+
+	start := time.Now()
+	err := command.Start()
+	if err != nil {
+		fmt.Fprintf(stderr, "Command Start Error: %v\n", err)
+		return newTestResult(testName, extensiontests.ResultFailed, start, time.Now(), stdout, stderr)
+	}
+
+	go func() {
+		select {
+		// interrupt tests after timeout, and abort if they don't complete quick enough
+		case <-time.After(timeout):
+			if command.Process != nil {
+				// we're not going to do anything with the err
+				_ = command.Process.Signal(syscall.SIGINT)
+			}
+			// if the process appears to be hung a significant amount of time after the timeout
+			// send an ABRT so we get a stack dump
+			select {
+			case <-time.After(time.Minute):
+				if command.Process != nil {
+					// we're not going to do anything with the err
+					_ = command.Process.Signal(syscall.SIGABRT)
+				}
+			case <-timeoutCtx.Done():
+				if command.Process != nil {
+					_ = command.Process.Signal(syscall.SIGABRT)
+				}
+			}
+		case <-timeoutCtx.Done():
+			if command.Process != nil {
+				_ = command.Process.Signal(syscall.SIGINT)
+			}
+		}
+	}()
+
+	result := extensiontests.ResultFailed
+	cmdErr := command.Wait()
+
+	subcommandResult, parseErr := newTestResultFromOutput(stdout)
+	if parseErr == nil {
+		// even if we have a cmdErr, if we were able to parse the result, trust the output
+		return subcommandResult
+	}
+
+	fmt.Fprintf(stderr, "Command Error: %v\n", cmdErr)
+	fmt.Fprintf(stderr, "Deserializaion Error: %v\n", parseErr)
+	return newTestResult(testName, result, start, time.Now(), stdout, stderr)
+}
+
+func newTestResultFromOutput(stdout *bytes.Buffer) (*extensiontests.ExtensionTestResult, error) {
+	if len(stdout.Bytes()) == 0 {
+		return nil, errors.New("no output from command")
+	}
+
+	// when the command runs correctly, we get json or json slice output
+	retArray := []extensiontests.ExtensionTestResult{}
+	if arrayItemErr := json.Unmarshal(stdout.Bytes(), &retArray); arrayItemErr == nil {
+		if len(retArray) != 1 {
+			return nil, errors.New("expected 1 result, got %v results")
+		}
+		return &retArray[0], nil
+	}
+
+	// when the command runs correctly, we get json output
+	ret := &extensiontests.ExtensionTestResult{}
+	if singleItemErr := json.Unmarshal(stdout.Bytes(), ret); singleItemErr != nil {
+		return nil, singleItemErr
+	}
+
+	return ret, nil
+}
+
+func newTestResult(name string, result extensiontests.Result, start, end time.Time, stdout, stderr *bytes.Buffer) *extensiontests.ExtensionTestResult {
+	duration := end.Sub(start)
+	dbStart := dbtime.DBTime(start)
+	dbEnd := dbtime.DBTime(start)
+	ret := &extensiontests.ExtensionTestResult{
+		Name:      name,
+		Lifecycle: "", // lifecycle is completed one level above this.
+		Duration:  int64(duration),
+		StartTime: &dbStart,
+		EndTime:   &dbEnd,
+		Result:    result,
+		Details:   nil,
+	}
+
+	if stdout != nil && stderr != nil {
+		stdoutStr := stdout.String()
+		stderrStr := stderr.String()
+
+		ret.Output = fmt.Sprintf("STDOUT:\n%s\n\nSTDERR:\n%s\n", stdoutStr, stderrStr)
+
+		// try to choose the best summary
+		switch {
+		case len(stderrStr) > 0 && len(stderrStr) < 5000:
+			ret.Error = stderrStr
+		case len(stderrStr) > 0 && len(stderrStr) >= 5000:
+			ret.Error = stderrStr[len(stderrStr)-5000:]
+
+		case len(stdoutStr) > 0 && len(stdoutStr) < 5000:
+			ret.Error = stdoutStr
+		case len(stdoutStr) > 0 && len(stdoutStr) >= 5000:
+			ret.Error = stdoutStr[len(stdoutStr)-5000:]
+		}
+	}
+
+	return ret
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
@@ -1,0 +1,200 @@
+package ginkgo
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
+
+	ext "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+)
+
+func configureGinkgo() (*types.SuiteConfig, *types.ReporterConfig, error) {
+	if !ginkgo.GetSuite().InPhaseBuildTree() {
+		if err := ginkgo.GetSuite().BuildTree(); err != nil {
+			return nil, nil, errors.Wrapf(err, "couldn't build ginkgo tree")
+		}
+	}
+
+	// Ginkgo initialization
+	ginkgo.GetSuite().ClearBeforeAndAfterSuiteNodes()
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	suiteConfig.RandomizeAllSpecs = true
+	suiteConfig.Timeout = 24 * time.Hour
+	reporterConfig.NoColor = true
+	reporterConfig.Verbose = true
+	ginkgo.SetReporterConfig(reporterConfig)
+
+	// Write output to Stderr
+	ginkgo.GinkgoWriter = ginkgo.NewWriter(os.Stderr)
+	ginkgo.GinkgoLogr = GinkgoLogrFunc(ginkgo.GinkgoWriter)
+
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	return &suiteConfig, &reporterConfig, nil
+}
+
+// BuildExtensionTestSpecsFromOpenShiftGinkgoSuite generates OTE specs for Gingko tests. While OTE isn't limited to
+// calling ginkgo tests, anything that implements the ExtensionTestSpec interface can be used, it's the most common
+// course of action.  The typical use case is to omit selectFns, but if provided, these will filter the returned list
+// of specs, applied in the order provided.
+func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunction) (ext.ExtensionTestSpecs, error) {
+	var specs ext.ExtensionTestSpecs
+	var enforceSerialExecutionForGinkgo sync.Mutex // in-process parallelization for ginkgo is impossible so far
+
+	if _, _, err := configureGinkgo(); err != nil {
+		return nil, err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't get current working directory")
+	}
+
+	ginkgo.GetSuite().WalkTests(func(name string, spec types.TestSpec) {
+		var codeLocations []string
+		for _, cl := range spec.CodeLocations() {
+			codeLocations = append(codeLocations, cl.String())
+		}
+
+		testCase := &ext.ExtensionTestSpec{
+			Name:          spec.Text(),
+			Labels:        sets.New[string](spec.Labels()...),
+			CodeLocations: codeLocations,
+			Lifecycle:     GetLifecycle(spec.Labels()),
+			Run: func(ctx context.Context) *ext.ExtensionTestResult {
+				enforceSerialExecutionForGinkgo.Lock()
+				defer enforceSerialExecutionForGinkgo.Unlock()
+
+				suiteConfig, reporterConfig, _ := configureGinkgo()
+
+				result := &ext.ExtensionTestResult{
+					Name: spec.Text(),
+				}
+
+				var summary types.SpecReport
+				ginkgo.GetSuite().RunSpec(spec, ginkgo.Labels{}, "", cwd, ginkgo.GetFailer(), ginkgo.GetWriter(), *suiteConfig,
+					*reporterConfig)
+				for _, report := range ginkgo.GetSuite().GetReport().SpecReports {
+					if report.NumAttempts > 0 {
+						summary = report
+					}
+				}
+
+				result.Output = summary.CapturedGinkgoWriterOutput
+				result.Error = summary.CapturedStdOutErr
+
+				switch {
+				case summary.State == types.SpecStatePassed:
+					result.Result = ext.ResultPassed
+				case summary.State == types.SpecStateSkipped:
+					result.Result = ext.ResultSkipped
+					if len(summary.Failure.Message) > 0 {
+						result.Output = fmt.Sprintf(
+							"%s\n skip [%s:%d]: %s\n",
+							result.Output,
+							lastFilenameSegment(summary.Failure.Location.FileName),
+							summary.Failure.Location.LineNumber,
+							summary.Failure.Message,
+						)
+					} else if len(summary.Failure.ForwardedPanic) > 0 {
+						result.Output = fmt.Sprintf(
+							"%s\n skip [%s:%d]: %s\n",
+							result.Output,
+							lastFilenameSegment(summary.Failure.Location.FileName),
+							summary.Failure.Location.LineNumber,
+							summary.Failure.ForwardedPanic,
+						)
+					}
+				case summary.State == types.SpecStateFailed, summary.State == types.SpecStatePanicked, summary.State == types.SpecStateInterrupted:
+					result.Result = ext.ResultFailed
+					var errors []string
+					if len(summary.Failure.ForwardedPanic) > 0 {
+						if len(summary.Failure.Location.FullStackTrace) > 0 {
+							errors = append(errors, fmt.Sprintf("\n%s\n", summary.Failure.Location.FullStackTrace))
+						}
+						errors = append(errors, fmt.Sprintf("fail [%s:%d]: Test Panicked: %s", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.ForwardedPanic))
+					}
+					errors = append(errors, fmt.Sprintf("fail [%s:%d]: %s", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message))
+					result.Error = strings.Join(errors, "\n")
+				default:
+					panic(fmt.Sprintf("test produced unknown outcome: %#v", summary))
+				}
+
+				return result
+			},
+			RunParallel: func(ctx context.Context) *ext.ExtensionTestResult {
+				// TODO pass through timeout and determine Lifecycle
+				return SpawnProcessToRunTest(ctx, name, 90*time.Minute)
+			},
+		}
+		specs = append(specs, testCase)
+	})
+
+	// Default select function is to exclude vendored specs.  When relying on Kubernetes test framework for its helpers,
+	// it also unfortunately ends up importing *all* Gingko specs.  This is unsafe: it would potentially override the
+	// kube specs already present in origin.  The best course of action is enforce this behavior on everyone.  If for
+	// some reason, you must include vendored specs, you can opt-in directly by supplying your own SelectFunctions or using
+	// AllTestsIncludedVendored().
+	if len(selectFns) == 0 {
+		selectFns = []ext.SelectFunction{ext.ModuleTestsOnly()}
+	}
+
+	for _, selectFn := range selectFns {
+		specs = specs.Select(selectFn)
+	}
+
+	return specs, nil
+}
+
+func Informing() ginkgo.Labels {
+	return ginkgo.Label(fmt.Sprintf("Lifecycle:%s", ext.LifecycleInforming))
+}
+
+func Slow() ginkgo.Labels {
+	return ginkgo.Label("SLOW")
+}
+
+func Blocking() ginkgo.Labels {
+	return ginkgo.Label(fmt.Sprintf("Lifecycle:%s", ext.LifecycleBlocking))
+}
+
+func GetLifecycle(labels ginkgo.Labels) ext.Lifecycle {
+	for _, label := range labels {
+		res := strings.Split(label, ":")
+		if len(res) != 2 || !strings.EqualFold(res[0], "lifecycle") {
+			continue
+		}
+		return MustLifecycle(res[1]) // this panics if unsupported lifecycle is used
+	}
+
+	return ext.LifecycleBlocking
+}
+
+func MustLifecycle(l string) ext.Lifecycle {
+	switch ext.Lifecycle(l) {
+	case ext.LifecycleInforming, ext.LifecycleBlocking:
+		return ext.Lifecycle(l)
+	default:
+		panic(fmt.Sprintf("unknown test lifecycle: %s", l))
+	}
+}
+
+func lastFilenameSegment(filename string) string {
+	if parts := strings.Split(filename, "/vendor/"); len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	if parts := strings.Split(filename, "/src/"); len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	return filename
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,6 +243,7 @@ github.com/openshift-eng/openshift-tests-extension/pkg/dbtime
 github.com/openshift-eng/openshift-tests-extension/pkg/extension
 github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests
 github.com/openshift-eng/openshift-tests-extension/pkg/flags
+github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo
 github.com/openshift-eng/openshift-tests-extension/pkg/junit
 github.com/openshift-eng/openshift-tests-extension/pkg/util/sets
 github.com/openshift-eng/openshift-tests-extension/pkg/version


### PR DESCRIPTION
- Add JUnit reporter configuration to generate XML reports for CI integration
- Create comprehensive README.md for OTE implementation based on openshift-apiserver example
- Add report.json and junit.xml to .gitignore to exclude generated files
- Document test execution, CI integration, and architecture details