### PR TITLE
Add priority field to prevent early shutdown

### DIFF
--- a/bindata/assets/kube-controller-manager/pod.yaml
+++ b/bindata/assets/kube-controller-manager/pod.yaml
@@ -201,6 +201,7 @@ spec:
     securityContext:
       readOnlyRootFilesystem: true
   hostNetwork: true
+  priority: 2000001000
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Based on the issue described here : https://github.com/kubernetes/kubernetes/issues/133442

priorityClassName is currently ignored by Kubelet for static pod files so setting this value has no impact on the gracefulShutdown order causing the static pods to start to be killed as soon as shutdown begins.

To prevent this we must set priority explicitly