### PR TITLE
CNTRLPLANE-1275: Fixed hardcode arch issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ export TP_CMD_PATH ?=./cmd/cluster-kube-controller-manager-operator
 
 # Build the openshift-tests-extension binary
 tests-ext-build:
-	GOOS=linux GOARCH=amd64 GO_COMPLIANCE_POLICY=exempt_all CGO_ENABLED=0 \
+	GOOS=$(if $(GOOS),$(GOOS),$(shell go env GOOS)) GOARCH=$(if $(GOARCH),$(GOARCH),$(shell go env GOARCH)) GO_COMPLIANCE_POLICY=exempt_all CGO_ENABLED=0 \
 	go build -o cluster-kube-controller-manager-operator-tests-ext \
 	-ldflags "-X 'main.CommitFromGit=$(shell git rev-parse --short HEAD)' \
 	-X 'main.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)' \


### PR DESCRIPTION
Replace hardcoded GOARCH=amd64 with dynamic
to support multiple architectures in tests-ext-build target.

Cherry-picked from master PR #866