### PR TITLE
NO-ISSUE: Use scrapeClass for service monitors

### DIFF
--- a/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_03_servicemonitor.yaml
@@ -10,8 +10,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     metricRelabelings:
     - action: drop
       regex: etcd_(debugging|disk|request|server).*
@@ -20,15 +19,9 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-kube-controller-manager-operator.svc
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-  jobLabel: component
-  namespaceSelector:
-    matchNames:
-    - openshift-kube-controller-manager-operator
+  jobLabel: app
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app: kube-controller-manager-operator
-

--- a/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
+++ b/manifests/0000_90_kube-controller-manager-operator_04_servicemonitor-controller-manager.yaml
@@ -51,8 +51,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     metricRelabelings:
     - action: drop
       regex: etcd_(debugging|disk|request|server).*
@@ -69,13 +68,8 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: kube-controller-manager.openshift-kube-controller-manager.svc
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-  namespaceSelector:
-    matchNames:
-    - openshift-kube-controller-manager
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       prometheus: kube-controller-manager


### PR DESCRIPTION
As documented in [1], the platform Prometheus servers are configured with a scrape class named `tls-client-certificate-auth` which automatically injects the client certificate and key files for mutual TLS into the scrape configuration of the service.

This commit also removes the `namespaceSelector` field of the service monitors: it isn't required when the service monitor and service are located in the same namespace. It also adjusts the `jobLabel` value to refer to the `app` label of the service.

[1] https://rhobs-handbook.netlify.app/products/openshiftmonitoring/collecting_metrics.md/#configuring-prometheus-to-scrape-metrics