### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,5 @@
 reviewers:
-  - atiratree
-  - deads2k
-  - ingvagabund
+  - control-plane-approvers
 approvers:
-  - atiratree
-  - deads2k
-  - ingvagabund
+  - control-plane-approvers
 component: "kube-controller-manager"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review governance structure for the controller manager component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->