### PR TITLE
CNTRLPLANE-3349: Migrate KCM-O cases to ote

### DIFF
--- a/cmd/cluster-kube-controller-manager-operator-tests-ext/dependencymagnet.go
+++ b/cmd/cluster-kube-controller-manager-operator-tests-ext/dependencymagnet.go
@@ -3,4 +3,5 @@ package main
 import (
 	_ "github.com/openshift/build-machinery-go"
 	_ "github.com/openshift/cluster-kube-controller-manager-operator/test/e2e"
+	_ "github.com/openshift/cluster-kube-controller-manager-operator/test/e2e-preferred-host"
 )

--- a/cmd/cluster-kube-controller-manager-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-controller-manager-operator-tests-ext/main.go
@@ -49,24 +49,33 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 	registry := oteextension.NewRegistry()
 	extension := oteextension.NewExtension("openshift", "payload", "cluster-kube-controller-manager-operator")
 
-	// TODO: enable the parallel suite once we have enough non-conflicting non-disruptive tests
-	// to justify a separate job.
-	// extension.AddSuite(oteextension.Suite{
-	// 	Name:        "openshift/cluster-kube-controller-manager-operator/operator/parallel",
-	// 	Parallelism: 4,
-	// 	Qualifiers: []string{
-	// 		`!name.contains("[Serial]") && !name.contains("[Disruptive]")`,
-	// 	},
-	// })
+	// parallel suite runs non-serial, non-disruptive tests concurrently with parallelism of 4.
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-kube-controller-manager-operator/operator/parallel",
+		Parallelism: 4,
+		Qualifiers: []string{
+			`!name.contains("[Serial]") && !name.contains("[Disruptive]")`,
+		},
+	})
 
-	// TODO: add Qualifiers to filter by [Serial] or [Disruptive] once the parallel suite is enabled.
+	// disruptive suite runs serial or disruptive tests one at a time, may impact cluster stability.
 	extension.AddSuite(oteextension.Suite{
 		Name:             "openshift/cluster-kube-controller-manager-operator/operator/disruptive",
 		Parallelism:      1,
 		ClusterStability: oteextension.ClusterStabilityDisruptive,
-		// Qualifiers: []string{
-		// 	`name.contains("[Serial]") || name.contains("[Disruptive]")`,
-		// },
+		Qualifiers: []string{
+			`(name.contains("[Serial]") || name.contains("[Disruptive]")) && !name.contains("[preferred-host]")`,
+		},
+	})
+
+	// preferred-host suite runs tests that validate KCM communication over the preferred host to KAS.
+	extension.AddSuite(oteextension.Suite{
+		Name:             "openshift/cluster-kube-controller-manager-operator/operator/preferred-host",
+		Parallelism:      1,
+		ClusterStability: oteextension.ClusterStabilityDisruptive,
+		Qualifiers: []string{
+			`name.contains("[Serial]") && name.contains("[Disruptive]") && name.contains("[preferred-host]")`,
+		},
 	})
 
 	specs, err := oteginkgo.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()

--- a/test/e2e-preferred-host/kcm_preferred_host_kas.go
+++ b/test/e2e-preferred-host/kcm_preferred_host_kas.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	g "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
@@ -40,10 +41,16 @@ var (
 	nsCreationPollInterval = 2 * time.Second
 )
 
+var _ = g.Describe("kube-controller-manager-operator [preferred-host]", func() {
+	g.It("TestKCMTalksOverPreferredHostToKAS [Serial][Disruptive]", func() {
+		testKCMTalksOverPreferredHostToKAS(g.GinkgoTB())
+	})
+})
+
 // TestKCMTalksOverPreferredHostToKAS points the KCM to a non available host
 // and sets unsupported-kube-api-over-localhost flag which changes it to use localhost instead.
 // It then waits for new KCM and tests if creating an SA works.
-func TestKCMTalksOverPreferredHostToKAS(t *testing.T) {
+func testKCMTalksOverPreferredHostToKAS(t testing.TB) {
 	// test data
 	kubeConfig, err := test.NewClientConfigForTest()
 	require.NoError(t, err)
@@ -83,7 +90,7 @@ func TestKCMTalksOverPreferredHostToKAS(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func readCurrentKubeAPIHostAndScheme(t *testing.T, openShiftClientSet configv1client.Interface) (string, string) {
+func readCurrentKubeAPIHostAndScheme(t testing.TB, openShiftClientSet configv1client.Interface) (string, string) {
 	infra, err := openShiftClientSet.ConfigV1().Infrastructures().Get(context.TODO(), "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
 
@@ -109,7 +116,7 @@ func readCurrentKubeAPIHostAndScheme(t *testing.T, openShiftClientSet configv1cl
 // createTestingNS should be used by every test, note that we append a common prefix to the provided test name.
 // Please see NewFramework instead of using this directly.
 // note this method has been copied from k/k repo
-func createTestingNS(t *testing.T, baseName string, c clientset.Interface) (*v1.Namespace, error) {
+func createTestingNS(t testing.TB, baseName string, c clientset.Interface) (*v1.Namespace, error) {
 	// We don't use ObjectMeta.GenerateName feature, as in case of API call
 	// failure we don't know whether the namespace was created and what is its
 	// name.

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -35,41 +35,134 @@ var _ = g.Describe("kube-controller-manager-operator", func() {
 		testOperatorNamespace(g.GinkgoTB())
 	})
 
-	g.It("TestPodDisruptionBudgetAtLimitAlert [Serial]", func() {
-		testPodDisruptionBudgetAtLimitAlert(g.GinkgoTB())
+	// TestPodDisruptionBudgetAtLimitAlert tests that PodDisruptionBudgetAtLimit alert behaves properly
+	g.Context("TestPodDisruptionBudgetAtLimitAlert [Serial]", func() {
+		tests := []struct {
+			name           string
+			createPod      bool
+			shouldAlert    bool
+			minAvailable   int
+			maxUnavailable int
+		}{
+			// test PodDisruptionBudgetAtLimit alert exists when there is a pdb at limit
+			// See https://bugzilla.redhat.com/show_bug.cgi?id=1762888
+			{
+				name:         "should alert when pdb at limit",
+				createPod:    true,
+				shouldAlert:  true,
+				minAvailable: 1,
+			},
+			// test PodDisruptionBudgetAtLimit alert missing when no app exists (currentHealthy and desiredHealthy equal to 0)
+			// See https://bugzilla.redhat.com/show_bug.cgi?id=2053622
+			{
+				name:           "should not alert when pdb at limit but no app pods exist",
+				createPod:      false,
+				shouldAlert:    false,
+				maxUnavailable: 1,
+			},
+		}
+		for _, test := range tests {
+			test := test
+			g.It(test.name, func() {
+				testPodDisruptionBudgetAtLimitAlert(g.GinkgoTB(), test.createPod, test.shouldAlert, test.minAvailable, test.maxUnavailable)
+			})
+		}
 	})
 
 	// This test deletes everything managed by the target config controller and expects it to be recreated
-	g.DescribeTable("TestTargetConfigController [Serial][Disruptive]",
-		func(namespace, resourceName string) {
-			testConfigMapDeletionCase(g.GinkgoTB(), namespace, resourceName)
-		},
-		g.Entry("KCM config", operatorclient.TargetNamespace, "config"),
-		g.Entry("cluster policy controller config", operatorclient.TargetNamespace, "cluster-policy-controller-config"),
-		g.Entry("csr-signer-ca", operatorclient.OperatorNamespace, "csr-signer-ca"),
-	)
+	g.Context("TestTargetConfigController [Serial][Disruptive]", func() {
+		tests := []struct {
+			name         string
+			resourceName string
+			namespace    string
+		}{
+			{
+				name:         "KCM config",
+				resourceName: "config",
+				namespace:    operatorclient.TargetNamespace,
+			},
+			{
+				name:         "cluster policy controller config",
+				resourceName: "cluster-policy-controller-config",
+				namespace:    operatorclient.TargetNamespace,
+			},
+			{
+				name:         "csr-signer-ca",
+				resourceName: "csr-signer-ca",
+				namespace:    operatorclient.OperatorNamespace,
+			},
+		}
+		for _, test := range tests {
+			test := test
+			g.It(test.name, func() {
+				testConfigMapDeletionCase(g.GinkgoTB(), test.namespace, test.resourceName)
+			})
+		}
+	})
 
 	// This test deletes everything managed by the resource sync controller and expects it to be recreated
-	g.DescribeTable("TestResourceSyncController [Serial][Disruptive]",
-		func(namespace, resourceName string) {
-			testConfigMapDeletionCase(g.GinkgoTB(), namespace, resourceName)
-		},
-		g.Entry("csr-controller-ca", operatorclient.OperatorNamespace, "csr-controller-ca"),
-		g.Entry("service-ca", operatorclient.TargetNamespace, "service-ca"),
-		g.Entry("client-ca", operatorclient.TargetNamespace, "client-ca"),
-		g.Entry("aggregator-client-ca", operatorclient.TargetNamespace, "aggregator-client-ca"),
-	)
+	g.Context("TestResourceSyncController [Serial][Disruptive]", func() {
+		tests := []struct {
+			name         string
+			resourceName string
+			namespace    string
+		}{
+			{
+				name:         "csr-controller-ca",
+				resourceName: "csr-controller-ca",
+				namespace:    operatorclient.OperatorNamespace,
+			},
+			{
+				name:         "service-ca",
+				resourceName: "service-ca",
+				namespace:    operatorclient.TargetNamespace,
+			},
+			{
+				name:         "client-ca",
+				resourceName: "client-ca",
+				namespace:    operatorclient.TargetNamespace,
+			},
+			{
+				name:         "aggregator-client-ca",
+				resourceName: "aggregator-client-ca",
+				namespace:    operatorclient.TargetNamespace,
+			},
+		}
+		for _, test := range tests {
+			test := test
+			g.It(test.name, func() {
+				testConfigMapDeletionCase(g.GinkgoTB(), test.namespace, test.resourceName)
+			})
+		}
+	})
 
 	// This test verifies that KCM can recover from having its lease deleted
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
-	g.DescribeTable("TestKCMLeaseRecovery",
-		func(leaseName string) {
-			testKCMLeaseRecovery(g.GinkgoTB(), leaseName)
-		},
-		g.Entry("kube-controller-manager", "kube-controller-manager"),
-		g.Entry("cert-recovery-controller-lock", "cert-recovery-controller-lock"),
-		g.Entry("cluster-policy-controller-lock", "cluster-policy-controller-lock"),
-	)
+	g.Context("TestKCMLeaseRecovery", func() {
+		tests := []struct {
+			name      string
+			leaseName string
+		}{
+			{
+				name:      "kube-controller-manager",
+				leaseName: "kube-controller-manager",
+			},
+			{
+				name:      "cert-recovery-controller-lock",
+				leaseName: "cert-recovery-controller-lock",
+			},
+			{
+				name:      "cluster-policy-controller-lock",
+				leaseName: "cluster-policy-controller-lock",
+			},
+		}
+		for _, test := range tests {
+			test := test
+			g.It(test.name, func() {
+				testKCMLeaseRecovery(g.GinkgoTB(), test.leaseName)
+			})
+		}
+	})
 
 	g.It("TestLogLevel [Serial]", func() {
 		testLogLevel(g.GinkgoTB())
@@ -92,8 +185,7 @@ func testOperatorNamespace(t testing.TB) {
 	}
 }
 
-// testPodDisruptionBudgetAtLimitAlert tests that PodDisruptionBudgetAtLimit alert behaves properly
-func testPodDisruptionBudgetAtLimitAlert(t testing.TB) {
+func testPodDisruptionBudgetAtLimitAlert(t testing.TB, createPod, shouldAlert bool, minAvailable, maxUnavailable int) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
@@ -116,125 +208,97 @@ func testPodDisruptionBudgetAtLimitAlert(t testing.TB) {
 
 	ctx := context.Background()
 
-	tests := []struct {
-		name           string
-		createPod      bool
-		shouldAlert    bool
-		minAvailable   int
-		maxUnavailable int
-	}{
-		// test PodDisruptionBudgetAtLimit alert exists when there is a pdb at limit
-		// See https://bugzilla.redhat.com/show_bug.cgi?id=1762888
-		{
-			name:         "should alert when pdb at limit",
-			createPod:    true,
-			shouldAlert:  true,
-			minAvailable: 1,
-		},
-		// test PodDisruptionBudgetAtLimit alert missing when no app exists (currentHealthy and desiredHealthy equal to 0)
-		// See https://bugzilla.redhat.com/show_bug.cgi?id=2053622
-		{
-			name:           "should not alert when pdb at limit but no app pods exist",
-			createPod:      false,
-			shouldAlert:    false,
-			maxUnavailable: 1,
-		},
-	}
-
-	// Warning: second test waits for this whole duration
+	// Warning: when shouldAlert is false, the test waits for this whole duration
 	testTimeout := time.Second * 120
 
-	for _, test := range tests {
-		name := names.SimpleNameGenerator.GenerateName("pdbtest-")
-		_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
+	name := names.SimpleNameGenerator.GenerateName("pdbtest-")
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
 		},
-			metav1.CreateOptions{},
-		)
+	},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("could not create test namespace: %v", err)
+	}
+	defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	err = testlib.WaitForServiceAccountInNamespace(kubeClient, name, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labels := map[string]string{"app": "pdbtest"}
+	err = pdbCreate(policyClient, name, minAvailable, maxUnavailable, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
+		pdb, err := policyClient.PodDisruptionBudgets(name).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("could not create test namespace: %v", err)
+			return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
 		}
-		defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
-		err = testlib.WaitForServiceAccountInNamespace(kubeClient, name, "default")
+		// Confirm the PDB is being reconciled by checking ObservedGeneration
+		if pdb.Status.ObservedGeneration == 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if createPod {
+		err = podCreate(kubeClient, name, labels)
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		labels := map[string]string{"app": "pdbtest"}
-		err = pdbCreate(policyClient, name, test.minAvailable, test.maxUnavailable, labels)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-			pdb, err := policyClient.PodDisruptionBudgets(name).Get(ctx, name, metav1.GetOptions{})
+		var pods *corev1.PodList
+		// Poll to confirm pod is running
+		wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
+			pods, err = kubeClient.CoreV1().Pods(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pdbtest"})
 			if err != nil {
-				return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
+				return false, err
 			}
-			// Confirm the PDB is being reconciled by checking ObservedGeneration
-			if pdb.Status.ObservedGeneration == 0 {
-				return false, nil
+			if len(pods.Items) > 0 && pods.Items[0].Status.Phase == corev1.PodRunning {
+				return true, nil
 			}
-			return true, nil
+			return false, nil
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+	}
 
-		if test.createPod {
-			err = podCreate(kubeClient, name, labels)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var pods *corev1.PodList
-			// Poll to confirm pod is running
-			wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-				pods, err = kubeClient.CoreV1().Pods(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pdbtest"})
-				if err != nil {
-					return false, err
-				}
-				if len(pods.Items) > 0 && pods.Items[0].Status.Phase == corev1.PodRunning {
-					return true, nil
-				}
-				return false, nil
-			})
-		}
-
-		// Now check for alert
-		prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
+	// Now check for alert
+	prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
+	if err != nil {
+		t.Fatalf("error creating route client for prometheus: %v", err)
+	}
+	var response model.Value
+	// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
+	// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
+	// The thanos behavior is to error on partial response.
+	query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
+	err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
+		response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
 		if err != nil {
-			t.Fatalf("error creating route client for prometheus: %v", err)
+			return false, fmt.Errorf("error querying prometheus: %v", err)
 		}
-		var response model.Value
-		// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
-		// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
-		// The thanos behavior is to error on partial response.
-		query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
-		err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
-			response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
-			if err != nil {
-				return false, fmt.Errorf("error querying prometheus: %v", err)
-			}
-			if len(response.String()) == 0 {
-				return false, nil
-			}
-			return true, nil
-		})
-		if test.shouldAlert {
-			if err != nil {
-				t.Fatalf("error querying prometheus: %v", err)
-			}
-		} else {
-			if !errors.Is(err, wait.ErrWaitTimeout) {
-				t.Fatalf("expected timeout err as alert should not be received, got: %v", err)
-			}
+		if len(response.String()) == 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	if shouldAlert {
+		if err != nil {
+			t.Fatalf("error querying prometheus: %v", err)
+		}
+	} else {
+		if !errors.Is(err, wait.ErrWaitTimeout) {
+			t.Fatalf("expected timeout err as alert should not be received, got: %v", err)
 		}
 	}
 }
 
-// testConfigMapDeletionCase deletes a configmap and expects it to be recreated by the responsible controller.
 func testConfigMapDeletionCase(t testing.TB, namespace, resourceName string) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
@@ -270,8 +334,6 @@ func testConfigMapDeletion(kubeClient *kubernetes.Clientset, namespace, config s
 	return err
 }
 
-// testKCMLeaseRecovery verifies that KCM can recover from having a lease deleted.
-// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
 func testKCMLeaseRecovery(t testing.TB, leaseName string) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -39,17 +39,37 @@ var _ = g.Describe("kube-controller-manager-operator", func() {
 		testPodDisruptionBudgetAtLimitAlert(g.GinkgoTB())
 	})
 
-	g.It("TestTargetConfigController [Serial][Disruptive]", func() {
-		testTargetConfigController(g.GinkgoTB())
-	})
+	// This test deletes everything managed by the target config controller and expects it to be recreated
+	g.DescribeTable("TestTargetConfigController [Serial][Disruptive]",
+		func(namespace, resourceName string) {
+			testConfigMapDeletionCase(g.GinkgoTB(), namespace, resourceName)
+		},
+		g.Entry("KCM config", operatorclient.TargetNamespace, "config"),
+		g.Entry("cluster policy controller config", operatorclient.TargetNamespace, "cluster-policy-controller-config"),
+		g.Entry("csr-signer-ca", operatorclient.OperatorNamespace, "csr-signer-ca"),
+	)
 
-	g.It("TestResourceSyncController [Serial][Disruptive]", func() {
-		testResourceSyncController(g.GinkgoTB())
-	})
+	// This test deletes everything managed by the resource sync controller and expects it to be recreated
+	g.DescribeTable("TestResourceSyncController [Serial][Disruptive]",
+		func(namespace, resourceName string) {
+			testConfigMapDeletionCase(g.GinkgoTB(), namespace, resourceName)
+		},
+		g.Entry("csr-controller-ca", operatorclient.OperatorNamespace, "csr-controller-ca"),
+		g.Entry("service-ca", operatorclient.TargetNamespace, "service-ca"),
+		g.Entry("client-ca", operatorclient.TargetNamespace, "client-ca"),
+		g.Entry("aggregator-client-ca", operatorclient.TargetNamespace, "aggregator-client-ca"),
+	)
 
-	g.It("TestKCMRecovery [Serial]", func() {
-		testKCMRecovery(g.GinkgoTB())
-	})
+	// This test verifies that KCM can recover from having its lease deleted
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
+	g.DescribeTable("TestKCMLeaseRecovery",
+		func(leaseName string) {
+			testKCMLeaseRecovery(g.GinkgoTB(), leaseName)
+		},
+		g.Entry("kube-controller-manager", "kube-controller-manager"),
+		g.Entry("cert-recovery-controller-lock", "cert-recovery-controller-lock"),
+		g.Entry("cluster-policy-controller-lock", "cluster-policy-controller-lock"),
+	)
 
 	g.It("TestLogLevel [Serial]", func() {
 		testLogLevel(g.GinkgoTB())
@@ -149,8 +169,13 @@ func testPodDisruptionBudgetAtLimitAlert(t testing.TB) {
 		}
 
 		err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-			if _, err := policyClient.PodDisruptionBudgets(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pbtest"}); err != nil {
+			pdb, err := policyClient.PodDisruptionBudgets(name).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
 				return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
+			}
+			// Confirm the PDB is being reconciled by checking ObservedGeneration
+			if pdb.Status.ObservedGeneration == 0 {
+				return false, nil
 			}
 			return true, nil
 		})
@@ -209,30 +234,8 @@ func testPodDisruptionBudgetAtLimitAlert(t testing.TB) {
 	}
 }
 
-func testTargetConfigController(t testing.TB) {
-	// This test deletes everything managed by the target config controller and expects it to be recreated
-	tests := []struct {
-		name         string
-		resourceName string
-		namespace    string
-	}{
-		{
-			name:         "targetconfigcontroller KCM config",
-			resourceName: "config",
-			namespace:    operatorclient.TargetNamespace,
-		},
-		{
-			name:         "targetconfigcontroller cluster policy controller config",
-			resourceName: "cluster-policy-controller-config",
-			namespace:    operatorclient.TargetNamespace,
-		},
-		{
-			name:         "targetconfigcontroller csr-signer-ca",
-			resourceName: "csr-signer-ca",
-			namespace:    operatorclient.OperatorNamespace,
-		},
-	}
-
+// testConfigMapDeletionCase deletes a configmap and expects it to be recreated by the responsible controller.
+func testConfigMapDeletionCase(t testing.TB, namespace, resourceName string) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
@@ -242,57 +245,9 @@ func testTargetConfigController(t testing.TB) {
 		t.Fatal(err)
 	}
 
-	for _, test := range tests {
-		err := testConfigMapDeletion(kubeClient, test.namespace, test.resourceName)
-		if err != nil {
-			t.Errorf("error waiting for creation of %s: %+v", test.resourceName, err)
-		}
-	}
-}
-
-func testResourceSyncController(t testing.TB) {
-	// This test deletes everything managed by the resource sync controller and expects it to be recreated
-	tests := []struct {
-		name         string
-		resourceName string
-		namespace    string
-	}{
-		{
-			name:         "resourcesynccontroller csr-controller-ca",
-			resourceName: "csr-controller-ca",
-			namespace:    operatorclient.OperatorNamespace,
-		},
-		{
-			name:         "resourcesynccontroller service-ca",
-			resourceName: "service-ca",
-			namespace:    operatorclient.TargetNamespace,
-		},
-		{
-			name:         "resourcesynccontroller client-ca",
-			resourceName: "client-ca",
-			namespace:    operatorclient.TargetNamespace,
-		},
-		{
-			name:         "resourcesynccontroller aggregator-client-ca",
-			resourceName: "aggregator-client-ca",
-			namespace:    operatorclient.TargetNamespace,
-		},
-	}
-
-	kubeConfig, err := testlib.NewClientConfigForTest()
+	err = testConfigMapDeletion(kubeClient, namespace, resourceName)
 	if err != nil {
-		t.Fatal(err)
-	}
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, test := range tests {
-		err = testConfigMapDeletion(kubeClient, test.namespace, test.resourceName)
-		if err != nil {
-			t.Errorf("error waiting for creation of %s: %+v", test.resourceName, err)
-		}
+		t.Errorf("error waiting for creation of %s: %+v", resourceName, err)
 	}
 }
 
@@ -315,9 +270,9 @@ func testConfigMapDeletion(kubeClient *kubernetes.Clientset, namespace, config s
 	return err
 }
 
-func testKCMRecovery(t testing.TB) {
-	// This is an e2e test to verify that KCM can recover from having its lease configmap deleted
-	// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
+// testKCMLeaseRecovery verifies that KCM can recover from having a lease deleted.
+// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
+func testKCMLeaseRecovery(t testing.TB, leaseName string) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
@@ -329,15 +284,15 @@ func testKCMRecovery(t testing.TB) {
 
 	ctx := context.Background()
 
-	// Try to delete the kube controller manager's lease object in kube-system
-	err = kubeClient.CoordinationV1().Leases("kube-system").Delete(ctx, "kube-controller-manager", metav1.DeleteOptions{})
+	// Try to delete the lease object in kube-system
+	err = kubeClient.CoordinationV1().Leases("kube-system").Delete(ctx, leaseName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Check to see that the lease object then gets recreated
 	err = wait.Poll(time.Second*5, time.Second*300, func() (bool, error) {
-		_, err := kubeClient.CoordinationV1().Leases("kube-system").Get(ctx, "kube-controller-manager", metav1.GetOptions{})
+		_, err := kubeClient.CoordinationV1().Leases("kube-system").Get(ctx, leaseName, metav1.GetOptions{})
 		if machineryerrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	g "github.com/onsi/ginkgo/v2"
+
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	machineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,7 +30,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOperatorNamespace(t *testing.T) {
+var _ = g.Describe("kube-controller-manager-operator", func() {
+	g.It("TestOperatorNamespace", func() {
+		testOperatorNamespace(g.GinkgoTB())
+	})
+
+	g.It("TestPodDisruptionBudgetAtLimitAlert [Serial]", func() {
+		testPodDisruptionBudgetAtLimitAlert(g.GinkgoTB())
+	})
+
+	g.It("TestTargetConfigController [Serial][Disruptive]", func() {
+		testTargetConfigController(g.GinkgoTB())
+	})
+
+	g.It("TestResourceSyncController [Serial][Disruptive]", func() {
+		testResourceSyncController(g.GinkgoTB())
+	})
+
+	g.It("TestKCMRecovery [Serial]", func() {
+		testKCMRecovery(g.GinkgoTB())
+	})
+
+	g.It("TestLogLevel [Serial]", func() {
+		testLogLevel(g.GinkgoTB())
+	})
+})
+
+func testOperatorNamespace(t testing.TB) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
@@ -44,8 +72,8 @@ func TestOperatorNamespace(t *testing.T) {
 	}
 }
 
-// TestPodDisruptionBudgetAtLimitAlert tests that PodDisruptionBudgetAtLimit alert behaves properly
-func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
+// testPodDisruptionBudgetAtLimitAlert tests that PodDisruptionBudgetAtLimit alert behaves properly
+func testPodDisruptionBudgetAtLimitAlert(t testing.TB) {
 	kubeConfig, err := testlib.NewClientConfigForTest()
 	if err != nil {
 		t.Fatal(err)
@@ -97,93 +125,91 @@ func TestPodDisruptionBudgetAtLimitAlert(t *testing.T) {
 	testTimeout := time.Second * 120
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			name := names.SimpleNameGenerator.GenerateName("pdbtest-")
-			_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
+		name := names.SimpleNameGenerator.GenerateName("pdbtest-")
+		_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
 			},
-				metav1.CreateOptions{},
-			)
-			if err != nil {
-				t.Fatalf("could not create test namespace: %v", err)
-			}
-			defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
-			err = testlib.WaitForServiceAccountInNamespace(kubeClient, name, "default")
-			if err != nil {
-				t.Fatal(err)
-			}
+		},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Fatalf("could not create test namespace: %v", err)
+		}
+		defer kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+		err = testlib.WaitForServiceAccountInNamespace(kubeClient, name, "default")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			labels := map[string]string{"app": "pdbtest"}
-			err = pdbCreate(policyClient, name, test.minAvailable, test.maxUnavailable, labels)
-			if err != nil {
-				t.Fatal(err)
-			}
+		labels := map[string]string{"app": "pdbtest"}
+		err = pdbCreate(policyClient, name, test.minAvailable, test.maxUnavailable, labels)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-				if _, err := policyClient.PodDisruptionBudgets(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pbtest"}); err != nil {
-					return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
-				}
-				return true, nil
-			})
-			if err != nil {
-				t.Fatal(err)
+		err = wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
+			if _, err := policyClient.PodDisruptionBudgets(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pbtest"}); err != nil {
+				return false, fmt.Errorf("waiting for poddisruptionbudget: %w", err)
 			}
-
-			if test.createPod {
-				err = podCreate(kubeClient, name, labels)
-				if err != nil {
-					t.Fatal(err)
-				}
-				var pods *corev1.PodList
-				// Poll to confirm pod is running
-				wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
-					pods, err = kubeClient.CoreV1().Pods(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pdbtest"})
-					if err != nil {
-						return false, err
-					}
-					if len(pods.Items) > 0 && pods.Items[0].Status.Phase == corev1.PodRunning {
-						return true, nil
-					}
-					return false, nil
-				})
-			}
-
-			// Now check for alert
-			prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
-			if err != nil {
-				t.Fatalf("error creating route client for prometheus: %v", err)
-			}
-			var response model.Value
-			// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
-			// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
-			// The thanos behavior is to error on partial response.
-			query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
-			err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
-				response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
-				if err != nil {
-					return false, fmt.Errorf("error querying prometheus: %v", err)
-				}
-				if len(response.String()) == 0 {
-					return false, nil
-				}
-				return true, nil
-			})
-			if test.shouldAlert {
-				if err != nil {
-					t.Fatalf("error querying prometheus: %v", err)
-				}
-			} else {
-				if !errors.Is(err, wait.ErrWaitTimeout) {
-					t.Fatalf("expected timeout err as alert should not be received, got: %v", err)
-				}
-			}
+			return true, nil
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if test.createPod {
+			err = podCreate(kubeClient, name, labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var pods *corev1.PodList
+			// Poll to confirm pod is running
+			wait.PollImmediate(time.Second*1, testTimeout, func() (bool, error) {
+				pods, err = kubeClient.CoreV1().Pods(name).List(ctx, metav1.ListOptions{LabelSelector: "app=pdbtest"})
+				if err != nil {
+					return false, err
+				}
+				if len(pods.Items) > 0 && pods.Items[0].Status.Phase == corev1.PodRunning {
+					return true, nil
+				}
+				return false, nil
+			})
+		}
+
+		// Now check for alert
+		prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
+		if err != nil {
+			t.Fatalf("error creating route client for prometheus: %v", err)
+		}
+		var response model.Value
+		// Note: prometheus/client_golang Alerts method only works with the deprecated prometheus-k8s route.
+		// Our helper uses the thanos-querier route.  Because of this, have to pass the entire alert as a query.
+		// The thanos behavior is to error on partial response.
+		query := fmt.Sprintf("ALERTS{alertname=\"PodDisruptionBudgetAtLimit\",alertstate=\"pending\",namespace=\"%s\",poddisruptionbudget=\"%s\",prometheus=\"openshift-monitoring/k8s\",severity=\"warning\"}==1", name, name)
+		err = wait.PollImmediate(time.Second*3, testTimeout, func() (bool, error) {
+			response, _, err = prometheusClient.Query(context.Background(), query, time.Now())
+			if err != nil {
+				return false, fmt.Errorf("error querying prometheus: %v", err)
+			}
+			if len(response.String()) == 0 {
+				return false, nil
+			}
+			return true, nil
+		})
+		if test.shouldAlert {
+			if err != nil {
+				t.Fatalf("error querying prometheus: %v", err)
+			}
+		} else {
+			if !errors.Is(err, wait.ErrWaitTimeout) {
+				t.Fatalf("expected timeout err as alert should not be received, got: %v", err)
+			}
+		}
 	}
 }
 
-func TestTargetConfigController(t *testing.T) {
+func testTargetConfigController(t testing.TB) {
 	// This test deletes everything managed by the target config controller and expects it to be recreated
 	tests := []struct {
 		name         string
@@ -217,16 +243,14 @@ func TestTargetConfigController(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := testConfigMapDeletion(kubeClient, test.namespace, test.resourceName)
-			if err != nil {
-				t.Errorf("error waiting for creation of %s: %+v", test.resourceName, err)
-			}
-		})
+		err := testConfigMapDeletion(kubeClient, test.namespace, test.resourceName)
+		if err != nil {
+			t.Errorf("error waiting for creation of %s: %+v", test.resourceName, err)
+		}
 	}
 }
 
-func TestResourceSyncController(t *testing.T) {
+func testResourceSyncController(t testing.TB) {
 	// This test deletes everything managed by the resource sync controller and expects it to be recreated
 	tests := []struct {
 		name         string
@@ -265,12 +289,10 @@ func TestResourceSyncController(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err = testConfigMapDeletion(kubeClient, test.namespace, test.resourceName)
-			if err != nil {
-				t.Errorf("error waiting for creation of %s: %+v", test.resourceName, err)
-			}
-		})
+		err = testConfigMapDeletion(kubeClient, test.namespace, test.resourceName)
+		if err != nil {
+			t.Errorf("error waiting for creation of %s: %+v", test.resourceName, err)
+		}
 	}
 }
 
@@ -293,7 +315,7 @@ func testConfigMapDeletion(kubeClient *kubernetes.Clientset, namespace, config s
 	return err
 }
 
-func TestKCMRecovery(t *testing.T) {
+func testKCMRecovery(t testing.TB) {
 	// This is an e2e test to verify that KCM can recover from having its lease configmap deleted
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1744984
 	kubeConfig, err := testlib.NewClientConfigForTest()
@@ -327,6 +349,49 @@ func TestKCMRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func testLogLevel(t testing.TB) {
+	kubeConfig, err := testlib.NewClientConfigForTest()
+	require.NoError(t, err)
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	operatorClientSet, err := operatorv1client.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	kcmOperator := operatorClientSet.KubeControllerManagers()
+	kcmOperatorConfig, err := kcmOperator.Get(context.TODO(), "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	kcmOperatorConfig.Spec.LogLevel = "Debug"
+	kcmOperator.Update(context.TODO(), kcmOperatorConfig, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// wait for KCM pods to be successfully running
+	// then check that "v=4" was added to the appropriate containers
+	var lastListErr error
+	err = wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		var pods *corev1.PodList
+		pods, lastListErr = kubeClient.CoreV1().Pods(operatorclient.TargetNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=kube-controller-manager"})
+		if lastListErr != nil {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				return false, nil
+			}
+			for _, container := range pod.Spec.Containers {
+				if container.Name == "kube-controller-manager-cert-syncer" {
+					continue
+				}
+				if !strings.Contains(container.Args[0], "v=4") {
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	})
+	require.NoError(t, lastListErr)
+	require.NoError(t, err)
 }
 
 func pdbCreate(client *policyclientv1.PolicyV1Client, name string, minAvailable int, maxUnavailable int, labels map[string]string) error {
@@ -390,47 +455,4 @@ func podCreate(client *kubernetes.Clientset, name string, labels map[string]stri
 	}
 	_, err := client.CoreV1().Pods(name).Create(context.Background(), pod, metav1.CreateOptions{})
 	return err
-}
-
-func TestLogLevel(t *testing.T) {
-	kubeConfig, err := testlib.NewClientConfigForTest()
-	require.NoError(t, err)
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	operatorClientSet, err := operatorv1client.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	kcmOperator := operatorClientSet.KubeControllerManagers()
-	kcmOperatorConfig, err := kcmOperator.Get(context.TODO(), "cluster", metav1.GetOptions{})
-	require.NoError(t, err)
-
-	kcmOperatorConfig.Spec.LogLevel = "Debug"
-	kcmOperator.Update(context.TODO(), kcmOperatorConfig, metav1.UpdateOptions{})
-	require.NoError(t, err)
-
-	// wait for KCM pods to be successfully running
-	// then check that "v=4" was added to the appropriate containers
-	var lastListErr error
-	err = wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
-		var pods *corev1.PodList
-		pods, lastListErr = kubeClient.CoreV1().Pods(operatorclient.TargetNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=kube-controller-manager"})
-		if lastListErr != nil {
-			return false, nil
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase != corev1.PodRunning {
-				return false, nil
-			}
-			for _, container := range pod.Spec.Containers {
-				if container.Name == "kube-controller-manager-cert-syncer" {
-					continue
-				}
-				if !strings.Contains(container.Args[0], "v=4") {
-					return false, nil
-				}
-			}
-		}
-		return true, nil
-	})
-	require.NoError(t, lastListErr)
-	require.NoError(t, err)
 }

--- a/test/e2e/satokensigner.go
+++ b/test/e2e/satokensigner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	g "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +19,13 @@ import (
 	test "github.com/openshift/cluster-kube-controller-manager-operator/test/library"
 )
 
-func TestSATokenSignerControllerSyncCerts(t *testing.T) {
+var _ = g.Describe("kube-controller-manager-operator SA token signer", func() {
+	g.It("TestSATokenSignerControllerSyncCerts [Serial][Disruptive]", func() {
+		testSATokenSignerControllerSyncCerts(g.GinkgoTB())
+	})
+})
+
+func testSATokenSignerControllerSyncCerts(t testing.TB) {
 	// initialize clients
 	kubeConfig, err := test.NewClientConfigForTest()
 	require.NoError(t, err)

--- a/test/library/cluster_operator.go
+++ b/test/library/cluster_operator.go
@@ -21,7 +21,7 @@ var (
 
 // WaitForKubeControllerManagerClusterOperator waits for ClusterOperator/kube-controller-manager to report
 // status as available, progressing, and failing as passed through arguments.
-func WaitForKubeControllerManagerClusterOperator(t *testing.T, ctx context.Context, client configclient.ConfigV1Interface, available, progressing, degraded configv1.ConditionStatus) {
+func WaitForKubeControllerManagerClusterOperator(t testing.TB, ctx context.Context, client configclient.ConfigV1Interface, available, progressing, degraded configv1.ConditionStatus) {
 	err := wait.Poll(WaitPollInterval, WaitPollTimeout, func() (bool, error) {
 		clusterOperator, err := client.ClusterOperators().Get(ctx, "kube-controller-manager", metav1.GetOptions{})
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Migrate KCM-O cases to ote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated end-to-end tests to Ginkgo v2 with suite-driven cases.
  * Replaced exported test entrypoints with unexported helpers invoked by Ginkgo.
  * Consolidated related scenarios into table-driven loops and tightened assertions to reduce flakiness.
  * Generalized signatures to testing.TB for flexible wiring.
  * Registered parallel, disruptive, and preferred-host suites with refined qualifiers.
  * Added the preferred-host tests to dependency imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->