### PR TITLE
CNTRLPLANE-3723: Add Agentic SDLC context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AI Agent Instructions for cluster-kube-controller-manager-operator
+
+> Also read [ARCHITECTURE.md](ARCHITECTURE.md) for design decisions and [CONTRIBUTING.md](CONTRIBUTING.md) for workflow.
+
+## What This Repo Is
+
+An OpenShift operator that manages the kube-controller-manager static pod on control plane nodes. It handles configuration rendering, certificate rotation, SA token signing key management, and static pod revision tracking. Built on [library-go](https://github.com/openshift/library-go)'s static pod operator framework. Installed by the Cluster Version Operator at run-level 25.
+
+## Repository Layout
+
+```text
+cmd/                                    # Entry points
+  cluster-kube-controller-manager-operator/  # Main operator binary
+  cluster-kube-controller-manager-operator-tests-ext/  # OTE test binary
+pkg/
+  operator/                             # Core operator logic
+    starter.go                          #   Controller wiring and startup
+    certrotationcontroller/             #   CSR signer + SA token key rotation
+    configobservation/                  #   Config observers (network, cloud, TLS, etc.)
+    gcwatchercontroller/                #   Garbage collector Prometheus watcher
+    resourcesynccontroller/             #   Cross-namespace resource sync
+    targetconfigcontroller/             #   Renders KCM config, kubeconfig, pod template
+    operatorclient/                     #   Namespace constants and client interface
+  cmd/                                  # Subcommands (operator, render, recoverycontroller, resourcegraph)
+bindata/
+  assets/                              # Operator-applied resources (RBAC, pod template, network policies)
+  bootkube/                            # Bootstrap-phase manifests
+manifests/                             # CVO-managed resources (deployment, RBAC, monitoring)
+test/
+  e2e/                                 # E2E tests (require OpenShift cluster)
+  e2e-preferred-host/                  # Preferred-host e2e tests
+```
+
+## Build and Test Commands
+
+```bash
+make build          # Build operator and test binaries
+make test-unit      # Unit tests (pkg/..., cmd/...)
+make test-e2e       # E2E tests (requires running cluster)
+make verify         # gofmt, govet, Go version checks
+make update         # Auto-fix gofmt issues
+```
+
+## Critical Rules
+
+1. **Never edit `vendor/` directly.** Change `go.mod`, then `go mod tidy && go mod vendor`. Always commit vendor changes separately from code changes for reviewable diffs.
+
+2. **Static pod template changes affect all control plane nodes.** `bindata/assets/kube-controller-manager/pod.yaml` defines four containers (kube-controller-manager, cluster-policy-controller, cert-syncer, recovery-controller). Changes here trigger rolling restarts across control plane.
+
+3. **CVO manifest ordering matters.** Files in `manifests/` are prefixed `0000_25_` for run-level 25. This operator must upgrade after kube-apiserver (run-level 20). Don't change the prefix.
+
+4. **Cert rotation has safety gates.** The SA token signer waits for bootstrap node departure and uses a 5-minute promotion delay. Don't bypass these — they prevent token validation failures cluster-wide.
+
+5. **This operator does not run in HyperShift.** The operator Deployment is excluded from hosted control plane topologies. HyperShift's control-plane-operator manages KCM directly.
+
+6. **Feature gate changes cause operator exit.** The operator process calls `os.Exit(0)` when the resolved feature gate set changes (by design, via library-go). This is a restart, not a crash.
+
+## Key Patterns
+
+- **Config observers** go in `pkg/operator/configobservation/<name>/` — one subdirectory per observer, each with its own unit tests. Observers write to `.status.observedConfig` on the KubeControllerManager CR.
+- **Static resources** go in `bindata/assets/kube-controller-manager/`. RBAC, namespaces, and network policies are applied by StaticResourceController (in `starter.go`, uses `bindata.Asset`). Config, pod template, and kubeconfig are applied by TargetConfigController (uses `bindata.MustAsset`).
+- **Resource syncing** uses ResourceSyncController to copy ConfigMaps/Secrets from `openshift-config` or `openshift-config-managed` to the target namespace. Don't read global config directly in controllers.
+- **Library-go factory pattern** for all controllers — use `factory.New().WithInformers().WithSync().ToController()`.
+- **Dual feature gate observers** — the ConfigObserver runs two separate feature gate observers: one for the KCM container (filters out OpenShift-only gates that KCM doesn't understand) and one for the cluster-policy-controller container (unfiltered). Both write to different paths in `.status.observedConfig`.
+
+## What NOT to Do
+
+- **Don't read cluster config directly in TargetConfigController.** Use the ObservedConfig pattern — ConfigObserver writes to the CR status, TargetConfigController reads from there.
+- **Don't add HyperShift logic.** This operator is standalone-only. HyperShift has its own KCM management.
+- **Don't modify `pkg/operator/configobservation/network/` without networking team review.** It has separate OWNERS.
+- **Don't skip `make verify` before submitting.** CI runs gofmt, govet, and Go version checks.
+
+## Test Suites
+
+- **Unit tests:** Colocated with source in `pkg/`. Run `make test-unit`.
+- **E2E tests:** In `test/e2e/` and `test/e2e-preferred-host/`. Require a running OpenShift cluster. Run `make test-e2e`.
+- **OTE integration:** Tests are registered with [openshift-tests-extension](https://github.com/openshift-eng/openshift-tests-extension). Suite: `openshift/cluster-kube-controller-manager-operator/operator/parallel`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,14 +17,16 @@ This operator manages the lifecycle of the **kube-controller-manager** static po
 
 ## Namespace Map
 
-| Namespace | Role |
-|-----------|------|
-| `openshift-kube-controller-manager-operator` | Operator pod, signing CAs, staging secrets |
-| `openshift-kube-controller-manager` | Target — static pod, revisioned ConfigMaps/Secrets |
-| `openshift-config` | User-specified global config (consumed, never written) |
-| `openshift-config-managed` | Machine-specified global config (consumed, never written) |
-| `kube-system` | Kubernetes system namespace (watched) |
-| `openshift-infra` | OpenShift infrastructure namespace (created and watched) |
+| Namespace | Constant | Role |
+|-----------|----------|------|
+| `openshift-kube-controller-manager-operator` | `OperatorNamespace` | Operator pod, signing CAs, staging secrets |
+| `openshift-kube-controller-manager` | `TargetNamespace` | Target — static pod, revisioned ConfigMaps/Secrets |
+| `openshift-config` | `GlobalUserSpecifiedConfigNamespace` | User-specified global config (consumed, never written) |
+| `openshift-config-managed` | `GlobalMachineSpecifiedConfigNamespace` | Machine-specified global config (consumed, never written) |
+| `kube-system` | — | Kubernetes system namespace (watched) |
+| `openshift-infra` | — | OpenShift infrastructure namespace (created and watched) |
+
+Constants are defined in `pkg/operator/operatorclient/interfaces.go`.
 
 ## Component Overview
 
@@ -128,6 +130,14 @@ With the `ConfigurablePKI` feature gate enabled ([enhancements#1882](https://git
 - **Unit tests** (`pkg/...`): ConfigObserver logic, target config rendering, cert rotation edge cases. Run with `make test-unit`.
 - **E2E tests** (`test/e2e/...`): Validate operator behavior on a live cluster — status reporting, static pod rollouts, network policy enforcement. Run with `make test-e2e`.
 - **OTE framework**: Tests are registered with [openshift-tests-extension](https://github.com/openshift-eng/openshift-tests-extension) for CI integration. Suite: `openshift/cluster-kube-controller-manager-operator/operator/parallel`.
+
+## Recovery Controller
+
+`pkg/cmd/recoverycontroller/` provides a certificate recovery mechanism for when CSR signing certificates have expired. It runs the cert rotation controller in `RefreshOnlyWhenExpired` mode to regenerate expired certificates, and includes a CSR approval controller that auto-approves kubelet CSRs signed by the recovered signer. Runs as a container in the static pod via the `cert-recovery-controller` subcommand.
+
+## Render Command
+
+`pkg/cmd/render/` is a bootstrap manifest renderer used during cluster installation. It takes installer-provided inputs (cloud provider config, feature gates, cluster CIDRs, images) and renders the initial set of manifests needed to bootstrap the kube-controller-manager before the operator is running. Templates live in `bindata/bootkube/`.
 
 ## Design Decisions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,12 +24,15 @@ This operator manages the lifecycle of the **kube-controller-manager** static po
 | `openshift-config` | User-specified global config (consumed, never written) |
 | `openshift-config-managed` | Machine-specified global config (consumed, never written) |
 | `kube-system` | Kubernetes system namespace (watched) |
+| `openshift-infra` | OpenShift infrastructure namespace (created and watched) |
 
 ## Component Overview
 
 The operator follows the **library-go static pod operator pattern**: observe cluster config, generate target config, create revisions, install static pods. All controllers use the library-go factory pattern with informer-driven work queues.
 
 This operator runs at CVO **run-level 25** (`0000_25_*` manifest prefix), meaning it upgrades *after* the kube-apiserver operator (run-level 20). This ordering is required because KCM must be N-1 compatible with the API server during upgrades.
+
+The operator process **exits on feature gate changes** — library-go's `NewFeatureGateAccess` calls `os.Exit(0)` if the resolved feature gate set changes, forcing a restart with the new gates. This is by design, not a crash.
 
 ```
  Cluster Config Resources              KubeControllerManager CR
@@ -59,7 +62,7 @@ This operator runs at CVO **run-level 25** (`0000_25_*` manifest prefix), meanin
 
 | Controller | Purpose | Key Watches | Key Outputs |
 |-----------|---------|-------------|-------------|
-| **ConfigObserver** | Observes cluster-wide config and writes `.status.observedConfig` on the CR | Infrastructure, Networks, FeatureGates, Proxies, Nodes, APIServers | ObservedConfig JSON on KubeControllerManager CR |
+| **ConfigObserver** | Observes cluster-wide config and writes `.status.observedConfig` on the CR. Runs two separate feature gate observers: one for KCM (filters out OpenShift-only gates) and one for CPC (unfiltered). | Infrastructure, Networks, FeatureGates, Proxies, Nodes, APIServers | ObservedConfig JSON on KubeControllerManager CR |
 | **TargetConfigController** | Renders KCM config, kubeconfig, pod template, and supporting ConfigMaps/Secrets | KubeControllerManager CR, Infrastructure | `config`, `controller-manager-kubeconfig`, `kube-controller-manager-pod` ConfigMaps; `csr-signer` Secret |
 | **ResourceSyncController** | Copies Secrets and ConfigMaps from global config namespaces to the target namespace | ConfigMaps/Secrets in `openshift-config`, `openshift-config-managed` | Synced copies in target namespace (`client-ca`, `service-ca`, etc.) |
 | **CertRotationController** | Rotates the CSR signing CA and leaf certificates | Secrets/ConfigMaps in operator and target namespaces, FeatureGates | `csr-signer-signer` CA, `csr-signer` leaf cert, `csr-controller-signer-ca` bundle |
@@ -85,7 +88,7 @@ This operator runs at CVO **run-level 25** (`0000_25_*` manifest prefix), meanin
 - **StaticResourceController** applies RBAC, namespace, network policies, and service accounts (uses `bindata.Asset`). Includes conditional vSphere resources.
 - **TargetConfigController** applies the pod template, config, kubeconfig, and recycler config (uses `bindata.MustAsset`).
 
-**Revision-tracked ConfigMaps:** `kube-controller-manager-pod`, `config`, `cluster-policy-controller-config`, `controller-manager-kubeconfig`, `cloud-config`, `serviceaccount-ca`, `service-ca`, `recycler-config`.
+**Revision-tracked ConfigMaps:** `kube-controller-manager-pod`, `config`, `cluster-policy-controller-config`, `controller-manager-kubeconfig`, `kube-controller-cert-syncer-kubeconfig`, `cloud-config`, `serviceaccount-ca`, `service-ca`, `recycler-config`.
 
 **Revision-tracked Secrets:** `service-account-private-key`, `serving-cert`, `localhost-recovery-client-token`.
 
@@ -141,3 +144,5 @@ With the `ConfigurablePKI` feature gate enabled ([enhancements#1882](https://git
 6. **ObservedConfig indirection:** Rather than reading cluster config directly in the target config controller, a separate ConfigObserver writes a merged JSON blob to `.status.observedConfig` on the CR. This decouples config sources from config consumers and makes the effective config inspectable via `oc get kubecontrollermanager cluster -o jsonpath='{.status.observedConfig}'`.
 
 7. **24-hour bootstrap signer with operator takeover:** The installer deliberately creates a short-lived CSR signer (24h) to minimize trust window during bootstrap. This operator's cert rotation controller takes ownership and issues a longer-lived replacement, ensuring the cluster transitions from minimal-trust bootstrap to managed cert lifecycle.
+
+8. **UseMoreSecureServiceCA bypasses ObservedConfig (tech debt):** The TargetConfigController reads `.spec.useMoreSecureServiceCA` directly from the operator spec rather than going through the ObservedConfig pattern. This is acknowledged in code as needing migration to a config observer, but requires changes to the observedConfig format.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,143 @@
+# Architecture: cluster-kube-controller-manager-operator
+
+## Scope
+
+This operator manages the lifecycle of the **kube-controller-manager** static pod on OpenShift control plane nodes. It handles configuration rendering, certificate rotation, service account token signing key management, and static pod revision tracking.
+
+**What it manages:**
+- The kube-controller-manager static pod and its configuration
+- CSR signing certificate rotation
+- Service account token signing key rotation
+- Resource syncing from global config namespaces to the target namespace
+
+**What it does NOT manage:**
+- The kube-controller-manager binary itself (that's upstream Kubernetes)
+- Cloud controller managers (separate operators per cloud provider)
+- The cluster-policy-controller binary (runs as a sidecar in the same pod, but this operator generates its config — see [Design Decisions](#design-decisions))
+
+## Namespace Map
+
+| Namespace | Role |
+|-----------|------|
+| `openshift-kube-controller-manager-operator` | Operator pod, signing CAs, staging secrets |
+| `openshift-kube-controller-manager` | Target — static pod, revisioned ConfigMaps/Secrets |
+| `openshift-config` | User-specified global config (consumed, never written) |
+| `openshift-config-managed` | Machine-specified global config (consumed, never written) |
+| `kube-system` | Kubernetes system namespace (watched) |
+
+## Component Overview
+
+The operator follows the **library-go static pod operator pattern**: observe cluster config, generate target config, create revisions, install static pods. All controllers use the library-go factory pattern with informer-driven work queues.
+
+This operator runs at CVO **run-level 25** (`0000_25_*` manifest prefix), meaning it upgrades *after* the kube-apiserver operator (run-level 20). This ordering is required because KCM must be N-1 compatible with the API server during upgrades.
+
+```
+ Cluster Config Resources              KubeControllerManager CR
+ (Infrastructure, Networks,            (operator.openshift.io/v1)
+  FeatureGates, Proxies)                        │
+         │                                      │
+         ▼                                      │
+ ┌─────────────────┐                            │
+ │ ConfigObserver   │── writes ObservedConfig ──▶│
+ └─────────────────┘                            │
+                                                ▼
+ ┌─────────────────┐    ┌──────────────────────────────┐
+ │ ResourceSync    │───▶│ TargetConfigController       │
+ │ (copies secrets │    │ (renders config, kubeconfig,  │
+ │  & CAs across   │    │  pod template, recycler cfg) │
+ │  namespaces)    │    └──────────────┬───────────────┘
+ └─────────────────┘                   │
+                                       ▼
+                        ┌──────────────────────────────┐
+                        │ Static Pod Controllers       │
+                        │ (Revision, Installer, Prune, │
+                        │  PDB Guard)                  │
+                        └──────────────────────────────┘
+```
+
+## Controllers
+
+| Controller | Purpose | Key Watches | Key Outputs |
+|-----------|---------|-------------|-------------|
+| **ConfigObserver** | Observes cluster-wide config and writes `.status.observedConfig` on the CR | Infrastructure, Networks, FeatureGates, Proxies, Nodes, APIServers | ObservedConfig JSON on KubeControllerManager CR |
+| **TargetConfigController** | Renders KCM config, kubeconfig, pod template, and supporting ConfigMaps/Secrets | KubeControllerManager CR, Infrastructure | `config`, `controller-manager-kubeconfig`, `kube-controller-manager-pod` ConfigMaps; `csr-signer` Secret |
+| **ResourceSyncController** | Copies Secrets and ConfigMaps from global config namespaces to the target namespace | ConfigMaps/Secrets in `openshift-config`, `openshift-config-managed` | Synced copies in target namespace (`client-ca`, `service-ca`, etc.) |
+| **CertRotationController** | Rotates the CSR signing CA and leaf certificates | Secrets/ConfigMaps in operator and target namespaces, FeatureGates | `csr-signer-signer` CA, `csr-signer` leaf cert, `csr-controller-signer-ca` bundle |
+| **SATokenSignerController** | Rotates the service account token signing key with a 5-minute promotion delay | Secrets in config namespaces, Endpoints (`default/kubernetes`), Pods in `openshift-kube-apiserver` | `service-account-private-key` Secret, `sa-token-signing-certs` history |
+| **GCWatcherController** | Monitors Prometheus for garbage collector sync failures | ClusterOperator/monitoring, Prometheus/Thanos queries | Status conditions on KubeControllerManager CR |
+| **Static Pod controllers** | Revision tracking, pod installation, pruning, PDB guard | ConfigMaps/Secrets in target namespace, Pods | Static pod manifest revisions, PodDisruptionBudget (HA only) |
+| **ClusterOperatorStatus** | Reports operator health to the ClusterOperator API | KubeControllerManager CR conditions | ClusterOperator/kube-controller-manager status |
+
+## CRDs and API Types
+
+**Owned:**
+- `KubeControllerManager` (`operator.openshift.io/v1`) — singleton named `cluster`. Embeds `StaticPodOperatorSpec`/`StaticPodOperatorStatus` from library-go.
+
+**Consumed:**
+- `Infrastructure`, `Network`, `FeatureGate`, `Proxy`, `APIServer` (`config.openshift.io/v1`)
+- `KubeControllerManagerConfig` (`kubecontrolplane.config.openshift.io/v1`) — the operand's config schema
+
+## Manifest and Resource Management
+
+**CVO-managed** (`manifests/`): Operator namespace, deployment, RBAC, ServiceMonitors, PrometheusRules, ClusterOperator status object. Prefixed `0000_25_` (run-level 25).
+
+**Operator-applied** (`bindata/assets/`): Split across two controllers:
+- **StaticResourceController** applies RBAC, namespace, network policies, and service accounts (uses `bindata.Asset`). Includes conditional vSphere resources.
+- **TargetConfigController** applies the pod template, config, kubeconfig, and recycler config (uses `bindata.MustAsset`).
+
+**Revision-tracked ConfigMaps:** `kube-controller-manager-pod`, `config`, `cluster-policy-controller-config`, `controller-manager-kubeconfig`, `cloud-config`, `serviceaccount-ca`, `service-ca`, `recycler-config`.
+
+**Revision-tracked Secrets:** `service-account-private-key`, `serving-cert`, `localhost-recovery-client-token`.
+
+**Unrevisioned certs** (changes trigger rollout but don't create new revisions): `aggregator-client-ca`, `client-ca`, `trusted-ca-bundle`, `kube-controller-manager-client-cert-key`, `csr-signer`.
+
+## Platform and Topology Behavior
+
+- **Standalone / Self-managed:** The operator runs on self-managed OpenShift clusters (HA and SNO). It is included in the release payload with `include.release.openshift.io/self-managed-high-availability: "true"` and `include.release.openshift.io/single-node-developer: "true"`.
+- **Single-node (SNO):** Detected via `IsSingleNodePlatformFn()`. Skips PodDisruptionBudget creation since there's only one control plane node.
+- **HyperShift (hosted control planes):** This operator does **not** run in HyperShift topology. The operator Deployment is explicitly excluded (`exclude.release.openshift.io/internal-openshift-hosted: "true"`). HyperShift's own control-plane-operator manages the kube-controller-manager directly. Only supporting resources (namespace, RBAC, monitoring) carry `include.release.openshift.io/hypershift: "true"` so the hosted cluster has the infrastructure the KCM operand needs.
+- **vSphere:** Applies additional legacy cloud provider RBAC from `bindata/assets/kube-controller-manager/vsphere/`.
+- **All platforms:** Reads `Infrastructure.Status.APIServerInternalURL` to render the KCM kubeconfig. Cloud provider config is injected via the ConfigObserver based on platform type.
+
+## Certificate Management
+
+| Certificate | Rotation Period | Validity | Storage |
+|------------|----------------|----------|---------|
+| CSR signer CA (`csr-signer-signer`) | 30 days (2h with `ShortCertRotation`) | 60 days | Secret in operator namespace |
+| CSR signer leaf (`csr-signer`) | Derived from CA | Derived from CA | Secret in target namespace |
+| SA token signing key | On-demand, 5-min promotion delay | N/A (RSA key pair) | Secret in target namespace + history ConfigMap |
+
+**Bootstrap transition:** The installer creates a CSR signer with only **24-hour validity** — deliberately short to limit blast radius during the least-trusted bootstrap phase. This operator's CertRotationController replaces it with a 30-day signer once the cluster is running. Target certs issued against the bootstrap signer are capped to the signer's remaining lifetime, so nodes must be operational within ~19 hours of install.
+
+The SA token signer waits for the bootstrap node to depart (by checking `default/kubernetes` endpoints against kube-apiserver pod IPs) before performing its first rotation.
+
+With the `ConfigurablePKI` feature gate enabled ([enhancements#1882](https://github.com/openshift/enhancements/blob/master/enhancements/api-review/1882-configurable-pki.md)), cert validity and refresh periods can be overridden via PKI profile custom resources. This operator is one of six that integrate with the configurable PKI framework (OCPSTRAT-2271).
+
+## Dependencies
+
+- **[library-go](https://github.com/openshift/library-go):** Static pod controllers, config observer framework, cert rotation primitives, resource sync, operator status reporting. This is the core framework dependency.
+- **[openshift/api](https://github.com/openshift/api):** CRD types (`KubeControllerManager`), config types, feature gate definitions.
+- **[openshift/client-go](https://github.com/openshift/client-go):** Generated clients for OpenShift API types.
+- **Upstream Kubernetes** (`k8s.io/*`): Client libraries, informer framework, API machinery.
+
+## Testing Strategy
+
+- **Unit tests** (`pkg/...`): ConfigObserver logic, target config rendering, cert rotation edge cases. Run with `make test-unit`.
+- **E2E tests** (`test/e2e/...`): Validate operator behavior on a live cluster — status reporting, static pod rollouts, network policy enforcement. Run with `make test-e2e`.
+- **OTE framework**: Tests are registered with [openshift-tests-extension](https://github.com/openshift-eng/openshift-tests-extension) for CI integration. Suite: `openshift/cluster-kube-controller-manager-operator/operator/parallel`.
+
+## Design Decisions
+
+1. **Static pod pattern over Deployment:** The kube-controller-manager runs as a static pod managed by kubelet, not as a Deployment. This avoids a circular dependency — KCM manages controllers that Deployments depend on (e.g., service account token controller). The operator writes pod manifests that kubelet picks up directly.
+
+2. **Revision-based rollouts:** Configuration changes create new revisions (numbered copies of ConfigMaps/Secrets). The installer controller rolls out one node at a time by writing a new static pod manifest referencing the latest revision. This provides rollback capability and audit trail.
+
+3. **Cluster-policy-controller as a sidecar:** The cluster-policy-controller ([openshift/cluster-policy-controller](https://github.com/openshift/cluster-policy-controller)) runs as a container in the KCM static pod rather than as a separate Deployment. This was a deliberate decision made for OpenShift 4.3 (PR #297, October 2019). The primary driver is a **bootstrap chicken-and-egg problem**: CPC's controllers (namespace SCC allocation, quota reconciliation, PSA label syncing) must be running before any Deployments can be scheduled — pods cannot be created without UID range and SELinux label allocation. Placing these controllers in a static pod breaks the circular dependency. The KCM pod was chosen because CPC shares the same service account (`system:kube-controller-manager`), RBAC, certificates, kubeconfig, and leader election namespace, avoiding infrastructure duplication.
+
+4. **5-minute SA key promotion delay:** New service account signing keys are staged in `next-service-account-private-key` for 5 minutes before promotion. This gives the kube-apiserver time to observe the new public key via the `sa-token-signing-certs` bundle, preventing token validation failures during rotation.
+
+5. **Bootstrap node departure gate:** SA token key rotation is blocked until the bootstrap node has left the cluster. The bootstrap node uses a different signing key; rotating before it departs could cause token validation failures for workloads it started.
+
+6. **ObservedConfig indirection:** Rather than reading cluster config directly in the target config controller, a separate ConfigObserver writes a merged JSON blob to `.status.observedConfig` on the CR. This decouples config sources from config consumers and makes the effective config inspectable via `oc get kubecontrollermanager cluster -o jsonpath='{.status.observedConfig}'`.
+
+7. **24-hour bootstrap signer with operator takeover:** The installer deliberately creates a short-lived CSR signer (24h) to minimize trust window during bootstrap. This operator's cert rotation controller takes ownership and issues a longer-lived replacement, ensuring the cluster transitions from minimal-trust bootstrap to managed cert lifecycle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to cluster-kube-controller-manager-operator
+
+## Prerequisites
+
+- Go 1.25+
+- Access to an OpenShift cluster (for e2e tests)
+
+## Development Workflow
+
+1. Fork the repo and clone your fork
+2. Create a feature branch from `main`
+3. Make your changes, add or update tests
+4. Run verification locally:
+   ```bash
+   make build
+   make test-unit
+   make verify
+   ```
+5. If you changed dependencies: `go mod tidy && go mod vendor` (commit vendor separately)
+6. Push your branch and open a PR
+
+## Building and Testing
+
+| Command | What It Runs |
+|---------|-------------|
+| `make build` | Builds the operator and test binaries |
+| `make test-unit` | Unit tests (`pkg/...`, `cmd/...`) |
+| `make test-e2e` | E2E tests (requires a running OpenShift cluster) |
+| `make verify` | Runs `gofmt`, `govet`, and Go version checks |
+| `make update` | Auto-fixes `gofmt` issues |
+
+### OTE (OpenShift Tests Extension)
+
+E2E tests use the [OTE framework](https://github.com/openshift-eng/openshift-tests-extension). After `make build`:
+
+```bash
+# List available suites
+./cluster-kube-controller-manager-operator-tests-ext list suites
+
+# Run the parallel suite
+./cluster-kube-controller-manager-operator-tests-ext run-suite \
+  openshift/cluster-kube-controller-manager-operator/operator/parallel -c 4
+
+# Run with JUnit output
+./cluster-kube-controller-manager-operator-tests-ext run-suite \
+  openshift/cluster-kube-controller-manager-operator/operator/parallel \
+  --junit-path "${ARTIFACT_DIR}/junit.xml"
+```
+
+## Pull Request Guidelines
+
+- Keep PRs focused — one logical change per PR.
+- Reference JIRA tickets in the PR title: `OCPBUGS-XXXXX: description` or `CNTRLPLANE-XXXX: description`. Use `NO-JIRA:` for non-ticket work.
+- Include tests for new functionality.
+- PRs require `/lgtm` from a reviewer and `/approve` from an approver (see [OWNERS](OWNERS)).
+- All PRs require `/verified` before merge — see the [OpenShift verification workflow](https://docs.google.com/document/d/1yqnJgOX_Q0LS_TlegrVjFqnP1toyXsWjEEHbOaYGFHE).
+
+## Code Conventions
+
+- Run `make verify` before submitting — CI will reject `gofmt` and `govet` failures.
+- Use library-go patterns for new controllers (factory, informer-driven sync).
+- Config observers go in `pkg/operator/configobservation/` — each observer in its own subdirectory with tests.
+- Static resources go in `bindata/assets/kube-controller-manager/`. RBAC and network policies are applied by StaticResourceController; config and pod template by TargetConfigController.
+
+## Areas Requiring Extra Care
+
+- **Vendored dependencies** (`vendor/`): Never edit directly. Change `go.mod`, then `go mod tidy && go mod vendor`. Always commit vendor changes separately from code changes.
+- **Static pod template** (`bindata/assets/kube-controller-manager/pod.yaml`): Changes here affect all control plane nodes. The pod runs four containers (kube-controller-manager, cluster-policy-controller, cert-syncer, recovery-controller).
+- **Network observer** (`pkg/operator/configobservation/network/`): Has its own OWNERS file — the networking team reviews changes here.
+- **CVO manifests** (`manifests/`): These are applied by the Cluster Version Operator. Ordering matters — files are prefixed with `0000_25_` for run-level 25.
+
+## CI Pipeline
+
+CI is powered by Prow and [ci-operator](https://docs.ci.openshift.org/). The build root image is defined in `.ci-operator.yaml`. PR jobs include:
+
+- `pull-ci-*-unit` — unit tests
+- `pull-ci-*-verify` — gofmt, govet, Go version checks
+- `pull-ci-*-images` — container image build
+
+E2E jobs run against ephemeral OpenShift clusters provisioned by ci-operator.
+
+## Review and Approval
+
+The `control-plane-approvers` team handles both review and approval (see [OWNERS_ALIASES](OWNERS_ALIASES)). Some subdirectories have their own OWNERS with separate reviewers/approvers — check `test/OWNERS` and `pkg/operator/configobservation/network/OWNERS`.

--- a/README.md
+++ b/README.md
@@ -1,127 +1,70 @@
 # Kubernetes Controller Manager operator
 
-The Kubernetes Controller Manager operator manages and updates the [Kubernetes Controller Manager](https://github.com/kubernetes/kubernetes) deployed on top of
-[OpenShift](https://openshift.io). The operator is based on OpenShift [library-go](https://github.com/openshift/library-go) framework and it
-is installed via [Cluster Version Operator](https://github.com/openshift/cluster-version-operator) (CVO).
+The Kube Controller Manager operator manages and updates the [kube-controller-manager](https://github.com/kubernetes/kubernetes) deployed on top of [OpenShift](https://openshift.io). The operator is based on the OpenShift [library-go](https://github.com/openshift/library-go) framework and is installed via the [Cluster Version Operator](https://github.com/openshift/cluster-version-operator) (CVO).
 
 It contains the following components:
 
 * Operator
 * Bootstrap manifest renderer
-* Installer based on static pods
+* Static pod installer
 * Configuration observer
 
-By default, the operator exposes [Prometheus](https://prometheus.io) metrics via `metrics` service.
-The metrics are collected from following components:
+## Quick Start
 
-* Kubernetes Controller Manager operator
+### Prerequisites
 
+- Go 1.25+
+- Access to an OpenShift cluster (for e2e testing)
+
+### Building
+
+```bash
+make build
+```
+
+### Running Tests
+
+```bash
+# Unit tests
+make test-unit
+
+# E2E tests (requires a running OpenShift cluster)
+make test-e2e
+```
+
+### Verification
+
+```bash
+make verify
+```
 
 ## Configuration
 
-The configuration for the Kubernetes Controller Manager is coming from:
+The Kube Controller Manager is configured via the [`KubeControllerManager`](https://github.com/openshift/api/blob/main/operator/v1/types_kubecontrollermanager.go) custom resource:
 
-* a [default config](https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/bindata/assets/config/defaultconfig.yaml)
+```bash
+oc describe kubecontrollermanager cluster
+```
 
+The default configuration is in [bindata/assets/config/defaultconfig.yaml](bindata/assets/config/defaultconfig.yaml).
+
+Log verbosity can be tuned via `.spec.logLevel` (for the operand) and `.spec.operatorLogLevel` (for the operator). Valid values: `Normal`, `Debug`, `Trace`, `TraceAll`.
 
 ## Debugging
 
-Operator also expose events that can help debugging issues. To get operator events, run following command:
+```bash
+# Operator events
+oc get events -n openshift-kube-controller-manager-operator
 
-```
-$ oc get events -n  openshift-kube-controller-manager-operator
-```
-
-This operator is configured via [`KubeControllerManager`](https://github.com/openshift/api/blob/master/operator/v1/types_kubecontrollermanager.go) custom resource:
-
-```
-$ oc describe kubecontrollermanager
-```
-```yaml
-apiVersion: operator.openshift.io/v1
-kind: KubeControllerManager
-metadata:
-  name: cluster
-spec:
-  managementState: Managed
-  ...
-```
-The log level of individual kube-controller-manager instances can be increased by setting `.spec.logLevel` field:
-```
-$ oc explain KubeControllerManager.spec.logLevel
-KIND:     KubeControllerManager
-VERSION:  operator.openshift.io/v1
-FIELD:    logLevel <string>
-DESCRIPTION:
-     logLevel is an intent based logging for an overall component. It does not
-     give fine grained control, but it is a simple way to manage coarse grained
-     logging choices that operators have to interpret for their operands. Valid
-     values are: "Normal", "Debug", "Trace", "TraceAll". Defaults to "Normal".
-```
-For example:
-```yaml
-apiVersion: operator.openshift.io/v1
-kind: KubeControllerManager
-metadata:
-  name: cluster
-spec:
-  logLevel: Debug
-  ...
+# Operator status
+oc get clusteroperator/kube-controller-manager
 ```
 
-Currently the log levels correspond to:
+## Developing
 
-| logLevel | log level |
-| -------- | --------- |
-| Normal   | 2         |
-| Debug    | 4         |
-| Trace    | 6         |
-| TraceAll | 10        |
+To use a custom operator image on a running cluster, override CVO management for the operator deployment:
 
-
-Similarly, the log level of cluster-kube-controller-manager-operator can be increased by setting the `.spec.operatorLogLevel` field:
-For example:
-```yaml
-apiVersion: operator.openshift.io/v1
-kind: KubeControllerManager
-metadata:
-  name: cluster
-spec:
-  operatorLogLevel: Debug
-  ...
-```
-
-Currently the operator log levels correspond to:
-
-| logLevel | log level |
-| -------- | --------- |
-| Normal   | 2         |
-| Debug    | 4         |
-| Trace    | 6         |
-| TraceAll | 8         |
-
-
-```
-$ oc explain kubecontrollermanager
-```
-to learn more about the resource itself.
-
-The current operator status is reported using the `ClusterOperator` resource. To get the current status you can run follow command:
-
-```
-$ oc get clusteroperator/kube-controller-manager
-```
-
-
-## Developing and debugging the operator
-
-In the running cluster [cluster-version-operator](https://github.com/openshift/cluster-version-operator/) is responsible
-for maintaining functioning and non-altered elements.  In that case to be able to use custom operator image one has to
-perform one of these operations:
-
-1. Set your operator in umanaged state, see [here](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusterversion.md) for details, in short:
-
-```
+```bash
 oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
 spec:
   overrides:
@@ -134,71 +77,46 @@ EOF
 )"
 ```
 
-2. Scale down cluster-version-operator:
+Then patch the deployment to use your image:
 
-```
-oc scale --replicas=0 deploy/cluster-version-operator -n openshift-cluster-version
-```
-
-IMPORTANT: This apprach disables cluster-version-operator completly, whereas previous only tells it to not manage a kube-controller-manager-operator!
-
-After doing this you can now change the image of the operator to the desired one:
-
-```
-oc patch deployment/kube-controller-manager-operator -n openshift-kube-controller-manager-operator -p '{"spec":{"template":{"spec":{"containers":[{"name":"kube-controller-manager-operator","image":"<user>/cluster-kube-controller-manager-operator","env":[{"name":"OPERATOR_IMAGE","value":"<user>/cluster-kube-controller-manager-operator"}]}]}}}}'
-```
-
-
-## Developing and debugging the bootkube bootstrap phase
-
-The operator image version used by the [installer](https://github.com/openshift/installer/blob/master/pkg/asset/ignition/bootstrap/) bootstrap phase can be overridden by creating a custom origin-release image pointing to the developer's operator `:latest` image:
-
-```
-$ IMAGE_ORG=<user> make images
-$ docker push <user>/origin-cluster-kube-controller-manager-operator
-
-$ cd ../cluster-kube-apiserver-operator
-$ IMAGES=cluster-kube-controller-manager-operator IMAGE_ORG=<user> make origin-release
-$ docker push <user>/origin-release:latest
-
-$ cd ../installer
-$ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=docker.io/<user>/origin-release:latest bin/openshift-install cluster ...
+```bash
+oc patch deployment/kube-controller-manager-operator -n openshift-kube-controller-manager-operator \
+  -p '{"spec":{"template":{"spec":{"containers":[{"name":"kube-controller-manager-operator","image":"<your-image>","env":[{"name":"OPERATOR_IMAGE","value":"<your-image>"}]}]}}}}'
 ```
 
 ## Tests
 
-This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
-
-### Building the test binary
+This repository uses the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
 
 ```bash
+# Build the test binary
 make build
-```
 
-### Running test suites and tests
-
-```bash
-# Run a specific test suite
-./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/operator/parallel
-
-# Run with parallel execution (4 workers)
-./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/operator/parallel -c 4
-
-# Run with JUnit output
-./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/operator/parallel --junit-path "${ARTIFACT_DIR}/junit.xml"
-
-# Run a specific test
-./cluster-kube-controller-manager-operator-tests-ext run-test "test-name"
-```
-
-### Listing available tests and suites
-
-```bash
-# List all test suites
+# List available test suites
 ./cluster-kube-controller-manager-operator-tests-ext list suites
 
-# List tests in a suite
-./cluster-kube-controller-manager-operator-tests-ext list tests --suite=openshift/cluster-kube-controller-manager-operator/operator/parallel
+# Run a test suite
+./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/operator/parallel
+
+# Run with parallel execution
+./cluster-kube-controller-manager-operator-tests-ext run-suite openshift/cluster-kube-controller-manager-operator/operator/parallel -c 4
 ```
 
-For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+## Metrics
+
+The operator exposes [Prometheus](https://prometheus.io) metrics via the `metrics` service by default.
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Design decisions and component architecture
+- [CONTRIBUTING.md](CONTRIBUTING.md) — How to submit changes
+- [AGENTS.md](AGENTS.md) — AI agent instructions
+
+## Related Repositories
+
+- [openshift/api](https://github.com/openshift/api) — API types including `KubeControllerManager`
+- [openshift/library-go](https://github.com/openshift/library-go) — Shared operator framework
+- [openshift/cluster-version-operator](https://github.com/openshift/cluster-version-operator) — Manages this operator's lifecycle
+- [openshift/cluster-kube-apiserver-operator](https://github.com/openshift/cluster-kube-apiserver-operator) — Sibling control plane operator
+- [openshift/cluster-kube-scheduler-operator](https://github.com/openshift/cluster-kube-scheduler-operator) — Sibling control plane operator
+- [openshift/cluster-policy-controller](https://github.com/openshift/cluster-policy-controller) — Runs as a sidecar in the KCM static pod


### PR DESCRIPTION
## Summary

- Add ARCHITECTURE.md — design decisions, controllers, cert management, platform/topology behavior
- Add CONTRIBUTING.md — dev workflow, build/test commands, PR guidelines, OWNERS structure
- Add AGENTS.md — AI agent instructions, repo layout, critical rules, key patterns
- Add CLAUDE.md symlink → AGENTS.md
- Update README.md — add Quick Start, fix stale master branch refs, add companion doc links, trim from 204 to 90 lines

## Test plan

- [ ] Verify all relative links resolve (ARCHITECTURE.md, CONTRIBUTING.md, AGENTS.md, defaultconfig.yaml)
- [ ] Verify CLAUDE.md symlink resolves to AGENTS.md
- [ ] Verify make targets listed in docs match actual Makefile
- [ ] Review ARCHITECTURE.md design decisions for accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide AI agent guidance with operator purpose, safe operational constraints, and pointers to unit/E2E/OTE test locations.
  * Added/expanded architecture documentation for static pod management, revision rollouts, certificate and service account token key rotation, and recovery/rendering flows.
  * Added complete contributing documentation covering prerequisites, build/test/verify commands, OTE suite execution, and PR review conventions.
  * Substantially rewrote README with a streamlined Quick Start, clearer configuration/debugging guidance, and updated custom-image workflow.
  * Updated CLAUDE.md to reference the shared agent guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->