### PR TITLE
OCPBUGS-38662: Add 10-minute degraded inertia for NodeControllerDegraded

### DIFF
--- a/pkg/operator/start_test.go
+++ b/pkg/operator/start_test.go
@@ -1,6 +1,0 @@
-package operator
-
-import "testing"
-
-func TestNothing(t *testing.T) {
-}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -21,6 +22,7 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/targetconfigcontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/latencyprofilecontroller"
@@ -249,7 +251,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		versionRecorder,
 		cc.EventRecorder,
 		cc.Clock,
-	)
+	).WithDegradedInertia(newDegradedInertia())
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
 		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
@@ -309,6 +311,18 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	<-ctx.Done()
 	return nil
+}
+
+func newDegradedInertia() status.Inertia {
+	return status.MustNewInertia(
+		2*time.Minute,
+		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		status.InertiaCondition{
+			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
+			Duration:             10 * time.Minute,
+		},
+	).Inertia
 }
 
 // deploymentConfigMaps is a list of configmaps that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,36 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	condition "github.com/openshift/library-go/pkg/operator/condition"
+)
+
+func TestNewDegradedInertia(t *testing.T) {
+	inertia := newDegradedInertia()
+
+	tests := []struct {
+		conditionType string
+		expected      time.Duration
+	}{
+		{
+			conditionType: condition.NodeControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
+			conditionType: "TargetConfigControllerDegraded",
+			expected:      2 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.conditionType, func(t *testing.T) {
+			got := inertia(operatorv1.OperatorCondition{Type: tt.conditionType})
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prevent transient node not-ready events from immediately marking the operator as Degraded at the ClusterOperator level. Other degraded conditions keep the default 2-minute inertia.

This replaces https://github.com/openshift/library-go/pull/2081 for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cluster operator status handling by adding a custom degraded inertia configuration to reduce rapid degraded-state flapping.
  * Added condition-specific degraded timing so different degraded condition types follow distinct inertia behavior.
* **Tests**
  * Added unit test coverage validating the degraded inertia timing for each targeted condition type.
  * Removed an obsolete empty unit test from the operator package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->