### PR TITLE
OCPBUGS-38662: Add 10-minute degraded inertia for StaticPodsDegraded

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -318,11 +318,18 @@ func newDegradedInertia() status.Inertia {
 		2*time.Minute,
 		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
-		status.InertiaCondition{
-			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
-			Duration:             10 * time.Minute,
-		},
+		inertiaForCondition(condition.NodeControllerDegradedConditionType, 10*time.Minute),
+		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
 	).Inertia
+}
+
+func inertiaForCondition(cond string, duration time.Duration) status.InertiaCondition {
+	return status.InertiaCondition{
+		ConditionTypeMatcher: regexp.MustCompile("^" + cond + "$"),
+		Duration:             duration,
+	}
 }
 
 // deploymentConfigMaps is a list of configmaps that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -20,6 +20,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: condition.StaticPodsDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},


### PR DESCRIPTION
Static pods may temporarily report errors during upgrades while pods restart. Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded degraded-condition handling so inertia now applies to both node-controller and static-pods degraded states.
  * This helps prevent short-lived status changes from triggering unnecessary degradation alerts.
* **Tests**
  * Updated coverage to validate the added degraded-condition duration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->