### PR TITLE
OCPBUGS-99770: Remove unnecessary namespace informers from kubeInformersForNamespaces

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -58,14 +58,15 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	}
 	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
 	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
+	// NamespaceAll ("") is intentionally not included — cluster-scoped static resources
+	// (ClusterRoles, ClusterRoleBindings) lose dynamic informer wiring but are still
+	// reconciled by the static resource controller on its 1-minute resync.
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient,
-		"",
 		operatorclient.GlobalUserSpecifiedConfigNamespace,
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
 		operatorclient.OperatorNamespace,
 		operatorclient.TargetNamespace,
 		"kube-system",
-		"openshift-infra",
 	)
 
 	operatorClient, dynamicInformers, err := genericoperatorclient.NewStaticPodOperatorClient(


### PR DESCRIPTION
Remove the cluster-wide ("") and "openshift-infra" namespace entries from kubeInformersForNamespaces. Both entries exist solely to provide dynamic wiring for the static resource controller via AddKubeInformers — no other controller in the operator ever queries either of them through InformersFor, ConfigMapLister, SecretLister, or PodLister.

The cluster-wide ("") entry gives dynamic wiring to cluster-scoped static resources (ClusterRoles and ClusterRoleBindings). A separate clusterInformers instance already provides the cluster-wide informer used by the static pod builder's node and guard controllers. The "" entry in kubeInformersForNamespaces creates a second, independent SharedInformerFactory that sets up its own watch connections for RBAC resources across all namespaces.

The "openshift-infra" entry gives dynamic wiring to two static resources: the openshift-infra Namespace and the pv-recycler-controller ServiceAccount. No controller reads configmaps, secrets, or pods from this namespace.

AddKubeInformers gracefully handles missing namespace entries — it logs a warning and skips dynamic wiring, falling back to the static resource controller's time-based reconciliation (every 10 minutes via resync). Since these are stable, rarely-changing resources, time-based reconciliation is sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource monitoring by limiting watches to the configured operator namespaces and `kube-system`.
  * Removed unnecessary monitoring of the empty namespace and `openshift-infra`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->