### PR TITLE
OCPBUGS-99770: remove duplicate wrappings of core_getters

### DIFF
--- a/pkg/cmd/recoverycontroller/csrcontroller.go
+++ b/pkg/cmd/recoverycontroller/csrcontroller.go
@@ -81,8 +81,8 @@ func NewCSRController(
 		"kube-controller-manager",
 		operatorClient,
 		kubeInformersForNamespaces,
-		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
-		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		kubeClient.CoreV1(), // getters are cached by the controller
+		kubeClient.CoreV1(),
 		c.eventRecorder,
 	)
 	err := operatorresourcesync.AddSyncCSRControllerCA(c.resourceSyncController)

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -45,8 +45,8 @@ func NewResourceSyncController(
 		"kube-controller-manager",
 		operatorConfigClient,
 		kubeInformersForNamespaces,
-		v1helpers.CachedSecretGetter(secretsGetter, kubeInformersForNamespaces),
-		v1helpers.CachedConfigMapGetter(configMapsGetter, kubeInformersForNamespaces),
+		secretsGetter, // getters are cached by the controller
+		configMapsGetter,
 		eventRecorder,
 	)
 	if err := AddSyncCSRControllerCA(resourceSyncController); err != nil {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -105,8 +105,8 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
 		operatorClient,
 		kubeInformersForNamespaces,
-		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
-		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		kubeClient.CoreV1(), // getters are cached by the controller
+		kubeClient.CoreV1(),
 		cc.EventRecorder,
 	)
 	if err != nil {


### PR DESCRIPTION
NewResourceSyncController does this by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of Kubernetes Secrets and ConfigMaps by using current cluster data directly.
  * Reduced the risk of resource updates being delayed by cached information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->