### PR TITLE
OCPBUGS-116225: [release-4.22] Add 10-minute degraded inertia

### DIFF
--- a/pkg/operator/start_test.go
+++ b/pkg/operator/start_test.go
@@ -1,6 +1,0 @@
-package operator
-
-import "testing"
-
-func TestNothing(t *testing.T) {
-}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -318,11 +318,18 @@ func newDegradedInertia() status.Inertia {
 		2*time.Minute,
 		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
-		status.InertiaCondition{
-			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
-			Duration:             10 * time.Minute,
-		},
+		inertiaForCondition(condition.NodeControllerDegradedConditionType, 10*time.Minute),
+		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
 	).Inertia
+}
+
+func inertiaForCondition(cond string, duration time.Duration) status.InertiaCondition {
+	return status.InertiaCondition{
+		ConditionTypeMatcher: regexp.MustCompile("^" + cond + "$"),
+		Duration:             duration,
+	}
 }
 
 // deploymentConfigMaps is a list of configmaps that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -21,6 +22,7 @@ import (
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/cluster-kube-controller-manager-operator/pkg/operator/targetconfigcontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/latencyprofilecontroller"
@@ -249,7 +251,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		versionRecorder,
 		cc.EventRecorder,
 		cc.Clock,
-	)
+	).WithDegradedInertia(newDegradedInertia())
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
 		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
@@ -309,6 +311,18 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	<-ctx.Done()
 	return nil
+}
+
+func newDegradedInertia() status.Inertia {
+	return status.MustNewInertia(
+		2*time.Minute,
+		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		status.InertiaCondition{
+			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
+			Duration:             10 * time.Minute,
+		},
+	).Inertia
 }
 
 // deploymentConfigMaps is a list of configmaps that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -46,6 +46,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const guardControllerDegradedConditionType = "GuardControllerDegraded"
+
 func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error {
 	// This kube client use protobuf, do not use it for CR
 	kubeClient, err := kubernetes.NewForConfig(cc.ProtoKubeConfig)
@@ -322,6 +324,9 @@ func newDegradedInertia() status.Inertia {
 		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
 		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
+		// Guard pods and PDBs may temporarily fail to reconcile during upgrades while nodes restart.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(guardControllerDegradedConditionType, 10*time.Minute),
 	).Inertia
 }
 

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,36 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	condition "github.com/openshift/library-go/pkg/operator/condition"
+)
+
+func TestNewDegradedInertia(t *testing.T) {
+	inertia := newDegradedInertia()
+
+	tests := []struct {
+		conditionType string
+		expected      time.Duration
+	}{
+		{
+			conditionType: condition.NodeControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
+			conditionType: "TargetConfigControllerDegraded",
+			expected:      2 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.conditionType, func(t *testing.T) {
+			got := inertia(operatorv1.OperatorCondition{Type: tt.conditionType})
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -20,6 +20,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: condition.StaticPodsDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -24,6 +24,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: guardControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},


### PR DESCRIPTION
I am creating a standalone backport PR to cherry-pick all relevant commits at once.